### PR TITLE
重构代码，将不同功能拆分成不同函数

### DIFF
--- a/UserScript.js
+++ b/UserScript.js
@@ -425,7 +425,7 @@ function addDataCol() {
             if (nowA) {
                 let deltaB = calcDeltaB(a);
                 tdTextA = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
-                    'align="center" data-from-calc="true" data-calc-a="' + deltaB.toFixed(2) + '">'
+                    'align="center" data-from-calc="true" data-calc-a="' + deltaB + '">'
                     + deltaB.toFixed(2) + '</td>';
                 let textAve = (deltaB / s).toFixed(2);
                 tdTextAve = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
@@ -435,7 +435,7 @@ function addDataCol() {
                 // data-from-calc用于判断该元素是否由脚本生成
                 tdTextA = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
                     'align="center" data-from-calc="true" data-calc-a="' + a + '">'
-                    + a + '</td>'
+                    + a.toFixed(2) + '</td>'
                 let textAve = makeTextAve(ave);
                 tdTextAve = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
                     'align="center" data-from-calc="true" data-calc-ave="' + ave + '">'

--- a/UserScript.js
+++ b/UserScript.js
@@ -469,9 +469,10 @@ function addDataCol() {
                         $this.children(":nth-last-child(2)").html(deltaB.toFixed(2));
                         $this.children(":nth-last-child(3)").html((deltaB / s).toFixed(2));
                     } else {
-                        $this.children("td:last").before('<td class="rowfollow" data-calc-a="' + deltaB + '">' +
-                            deltaB.toFixed(2) + '</td>', '<td class="rowfollow" data-calc-ave="' +
-                            deltaB / s + '">' + (deltaB / s).toFixed(2) + '</td>');
+                        $this.children("td:last").before('<td class="rowfollow" data-calc-a="' + deltaB + '" ' +
+                            'title="A: ' + a.toFixed(2) + '">' + deltaB.toFixed(2) + '</td>',
+                            '<td class="rowfollow" data-calc-ave="' + deltaB / s + '" title="A/GB: ' + ave + '">'
+                            + (deltaB / s).toFixed(2) + '</td>');
                     }
                 } else {
                     $this.children("td:last").before('<td class="rowfollow" data-calc-a="' + a +
@@ -515,12 +516,12 @@ function addDataCol() {
             if (nowA) {
                 let deltaB = calcDeltaB(a);
                 tdTextA = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
-                    'align="center" data-from-calc="true" data-calc-a="' + deltaB + '">'
-                    + deltaB.toFixed(2) + '</td>';
+                    'align="center" data-from-calc="true" data-calc-a="' + deltaB + '" title="A: ' +
+                    a.toFixed(2) + '">' + deltaB.toFixed(2) + '</td>';
                 textAve = (deltaB / s).toFixed(2);
                 tdTextAve = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
-                    'align="center" data-from-calc="true" data-calc-ave="' + (deltaB / s) + '">'
-                    + textAve + '</td>';
+                    'align="center" data-from-calc="true" data-calc-ave="' + (deltaB / s) + '" title="A/GB: ' +
+                    ave + '">' + textAve + '</td>';
             } else {
                 // data-from-calc用于判断该元素是否由脚本生成
                 tdTextA = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +

--- a/UserScript.js
+++ b/UserScript.js
@@ -452,7 +452,7 @@ function addDataCol() {
                         'id="calcTHeadA" title="' + aTitle + '">' + aHeadText + '</td>',
                         '<td class="colhead" style="cursor: pointer;" ' +
                         'id="calcTHeadAve" title="' + aveTitle + '">' + aveHeadText + '</td>');
-                }else{
+                } else {
                     $("#calcTHeadA").attr('title', aTitle);
                     $("#calcTHeadAve").attr('title', aveTitle);
                 }
@@ -567,6 +567,10 @@ function addDataCol() {
     function sortTable() {
         const $aHeader = $('#calcTHeadA');
         const $aveHeader = $('#calcTHeadAve');
+        if (sortBy === 0) {
+            $aHeader.html(aHeadText);
+            $aveHeader.html(aveHeadText);
+        }
         const $tbody = $aHeader.closest('table').children('tbody');
         let rows;
         if (isMTeam) {

--- a/UserScript.js
+++ b/UserScript.js
@@ -466,8 +466,12 @@ function addDataCol() {
                 if (nowA) {
                     let deltaB = calcDeltaB(a);
                     if (addFlag) {
-                        $this.children(":nth-last-child(3)").html(deltaB.toFixed(2));
-                        $this.children(":nth-last-child(2)").html((deltaB / s).toFixed(2));
+                        const colA = $this.children(":nth-last-child(3)");
+                        const colAve = $this.children(":nth-last-child(2)");
+                        colA.html(deltaB.toFixed(2));
+                        colA.attr('title', 'A: ' + a.toFixed(2));
+                        colAve.html((deltaB / s).toFixed(2));
+                        colAve.attr('title', 'A/GB: ' + ave);
                     } else {
                         $this.children("td:last").before('<td class="rowfollow" data-calc-a="' + deltaB + '" ' +
                             'title="A: ' + a.toFixed(2) + '">' + deltaB.toFixed(2) + '</td>',

--- a/UserScript.js
+++ b/UserScript.js
@@ -6,6 +6,10 @@
 // @author       neoblackxt, LaneLau
 // @require      https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js
 // @require      https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js
+// @require      https://cdn.jsdelivr.net/npm/toastify-js
+// @resource     TOASTIFY_CSS https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css
+// @grant        GM_addStyle
+// @grant        GM_getResourceText
 // @match        *://*.beitai.pt/torrents*
 // @match        *://*.pttime.org/torrents*
 // @match        *://*.ptsbao.club/torrents*
@@ -88,7 +92,11 @@ function getParamsFromBonusPage(site) {
     }
 
     if (!argsReady || newT0 !== T0 || newN0 !== N0 || newB0 !== B0 || newL !== L) {
-        alert("魔力值参数已更新")
+        Toastify({
+            text: "魔力值参数已更新",
+            duration: 3000,
+            close: true
+        }).showToast()
         GM_setValue(siteName + ".T0", newT0);
         GM_setValue(siteName + ".N0", newN0);
         GM_setValue(siteName + ".B0", newB0);
@@ -201,7 +209,7 @@ function run() {
     if (!site) {
         site = {
             name: host,
-            host: [host],
+            host: [window.location.host],
             bonusPage: "/mybonus",
             torrentListPage: "/torrents"
         }
@@ -224,7 +232,13 @@ function addDataCol(site) {
     let B0 = GM_getValue(siteName + ".B0");
     let L = GM_getValue(siteName + ".L");
     if (!(T0 && N0 && B0 && L)) {
-        alert("请先访问 " + site.host[0] + site.bonusPage + " 以获取魔力值参数");
+        let bonusPageUrl = window.location.protocol + "//" + site.host[0] + site.bonusPage;
+        Toastify({
+            text: "请先访问 " + bonusPageUrl + " 以获取魔力值参数",
+            destination: bonusPageUrl,
+            duration: 3000,
+            close: true
+        }).showToast();
         return;
     }
 
@@ -305,7 +319,11 @@ function addDataCol(site) {
                     }
                 })
                 if (!i_T || !i_S || !i_N) {
-                    alert('未能找到数据列')
+                    Toastify({
+                        text: "未能找到数据列",
+                        duration: 3000,
+                        close: true
+                    }).showToast();
                     return
                 }
                 $this.children("td:last").before("<td class=\"colhead\" title=\"A值@每GB的A值\">A@A/GB</td>");
@@ -403,3 +421,5 @@ if (window.onurlchange === null) {
     // M-Team 页面局部刷新时重新运行函数
     window.addEventListener('urlchange', (info) => mTeamWaitPageLoadAndRun());
 }
+
+GM_addStyle(GM_getResourceText("TOASTIFY_CSS"));

--- a/UserScript.js
+++ b/UserScript.js
@@ -479,6 +479,7 @@ function mTeamWaitPageLoadAndRun() {
 
 let host = window.location.host.match(/\b[^\.]+\.[^\.]+$/)[0]
 let isMTeam = window.location.toString().indexOf("m-team") != -1
+let mTeamUrl
 let seedTableSelector = isMTeam ? 'div.ant-spin-container:not(.ant-spin-blur)>div.mt-4>table>tbody>tr' : '.torrents:last-of-type>tbody>tr'
 let isMybonusPage = window.location.toString().indexOf("mybonus") != -1
 if (window.location.toString().indexOf("tjupt.org") != -1) {
@@ -486,6 +487,7 @@ if (window.location.toString().indexOf("tjupt.org") != -1) {
 }
 if (isMTeam) {
     if (isMybonusPage || window.location.toString().indexOf("browse") != -1) {
+        mTeamUrl = window.location.toString()
         mTeamWaitPageLoadAndRun()
     }
 } else {
@@ -494,7 +496,12 @@ if (isMTeam) {
 
 if (window.onurlchange === null) {
     // M-Team 页面局部刷新时重新运行函数
-    window.addEventListener('urlchange', (info) => mTeamWaitPageLoadAndRun());
+    window.addEventListener('urlchange', (info) => {
+		if (info.url !== mTeamUrl) {
+            mTeamUrl = window.location.toString()
+            mTeamWaitPageLoadAndRun();
+        }
+    });
 }
 
 GM_addStyle(GM_getResourceText("TOASTIFY_CSS"));

--- a/UserScript.js
+++ b/UserScript.js
@@ -517,12 +517,13 @@ function addDataCol() {
         $(seedTableSelector).each(function (row) {
             const $this = $(this);
             let {a, ave, s} = makeA($this, i_T, i_S, i_N)
-            let tdTextA, tdTextAve, textAve;
+            let tdTextA, tdTextAve, textAve, textA;
             if (nowA) {
                 let deltaB = calcDeltaB(a);
                 tdTextA = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
                     'align="center" data-from-calc="true" data-calc-a="' + deltaB + '" title="A: ' +
                     a.toFixed(2) + '">' + deltaB.toFixed(2) + '</td>';
+                textA = deltaB.toFixed(2);
                 textAve = (deltaB / s).toFixed(2);
                 tdTextAve = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
                     'align="center" data-from-calc="true" data-calc-ave="' + (deltaB / s) + '" title="A/GB: ' +
@@ -532,14 +533,17 @@ function addDataCol() {
                 tdTextA = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
                     'align="center" data-from-calc="true" data-calc-a="' + a + '">'
                     + a.toFixed(2) + '</td>'
+                textA = a.toFixed(2);
                 textAve = makeTextAve(ave);
                 tdTextAve = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
                     'align="center" data-from-calc="true" data-calc-ave="' + ave + '">'
                     + textAve + '</td>';
             }
             if ($this.children("td:last").data("fromCalc")) {
-                $this.children(":nth-last-child(2)").html(a.toFixed(2));
+                $this.children(":nth-last-child(2)").html(textA);
+                $this.children(":nth-last-child(2)").attr("title", a.toFixed(2));
                 $this.children("td:last").html(textAve);
+                $this.children("td:last").attr("title", ave);
             } else {
                 $this.children("td:last").after(tdTextA, tdTextAve);
             }
@@ -627,18 +631,14 @@ function addDataCol() {
 function mTeamWaitPageLoadAndRun() {
     let $ = jQuery
     let contentObserver = new MutationObserver((mutationsList, observer) => {
-        let T0Found = false;
-        let seedTableFound = false;
         let isMybonusPage = window.location.toString().indexOf("mybonus") != -1
         if (isMybonusPage) {
-            T0Found = $("li:has(b:contains('T0'))")[1];
-        }
-        if (T0Found) {
-            observer.disconnect();
-            run();
+            if ($("li:has(b:contains('T0'))")[1]) {
+                observer.disconnect();
+                run();
+            }
         } else {
-            seedTableFound = $(seedTableSelector)[1];
-            if (seedTableFound) {
+            if ($(seedTableSelector)[1]) {
                 observer.disconnect();
                 run();
             }

--- a/UserScript.js
+++ b/UserScript.js
@@ -207,10 +207,16 @@ function run() {
     let site = siteInfo.find(site => site.host.includes(window.location.host));
     // 未在预设站点中找到，使用默认配置
     if (!site) {
+        const mybonusLinks = $("a:contains('使用')");
+        let targetHref = mybonusLinks.length > 0 ? mybonusLinks.eq(0).prop("href") : null;
+        if (targetHref) {
+            let pathParts = targetHref.split("/");
+            targetHref = pathParts.length > 0 ? "/" + pathParts[pathParts.length-1] : null;
+        }
         site = {
             name: host,
             host: [window.location.host],
-            bonusPage: "/mybonus",
+            bonusPage: targetHref || "/mybonus.php",
             torrentListPage: "/torrents"
         }
     }

--- a/UserScript.js
+++ b/UserScript.js
@@ -383,6 +383,10 @@ function addDataCol() {
         var N = parseInt(number);
         var A = calcA(T, S, N);
         var ave = (A / S).toFixed(2);
+        // tjupt的“魔力值详情”页面可以看到当前做种种子的A值，比对发现带“保种”标签种子的A值是公式计算A值的5倍
+        if (site.name === "tjupt" && $this.find(".tag-keepseed")) {
+            A = 5 * A;
+        }
         return {a: A, ave: ave, s: S};
     }
 

--- a/UserScript.js
+++ b/UserScript.js
@@ -381,7 +381,7 @@ function addDataCol() {
         var A = calcA(T, S, N);
         var ave = (A / S).toFixed(2);
         // tjupt的“魔力值详情”页面可以看到当前做种种子的A值，比对发现带“保种”标签种子的A值是公式计算A值的5倍
-        if (site.name === "tjupt" && $this.find(".tag-keepseed")) {
+        if (site.name === "tjupt" && $this.find(".tag-keepseed").length !== 0) {
             A = 5 * A;
         }
         return {a: A, ave: ave, s: S};
@@ -408,10 +408,11 @@ function addDataCol() {
     }
 
     let nowA = parseFloat(getCookie("calcBonusA"));
-    let aHeadText = nowA ? "时魔" : "A";
-    let aTitle = nowA ? "当前做种状态下每小时可以获得的魔力值" : "A值";
-    let aveHeadText = nowA ? "时魔/GB" : "A/GB";
-    let aveTitle = nowA ? "当前做种状态下每GB每小时可以获得的魔力值" : "每GB的A值";
+    let hasNowA = !isNaN(nowA);
+    let aHeadText = hasNowA ? "时魔" : "A";
+    let aTitle = hasNowA ? "当前做种状态下每小时可以获得的魔力值" : "A值";
+    let aveHeadText = hasNowA ? "时魔/GB" : "A/GB";
+    let aveTitle = hasNowA ? "当前做种状态下每GB每小时可以获得的魔力值" : "每GB的A值";
 
     function calcB(A) {
         return B0 * (2 / Math.PI) * Math.atan(A / L)
@@ -464,7 +465,7 @@ function addDataCol() {
             } else {
                 let {a, ave, s} = makeA($this, i_T, i_S, i_N);
                 let textAve = makeTextAve(ave);
-                if (nowA) {
+                if (hasNowA) {
                     let deltaB = calcDeltaB(a);
                     if (addFlag) {
                         const colA = $this.children(":nth-last-child(3)");
@@ -518,7 +519,7 @@ function addDataCol() {
             const $this = $(this);
             let {a, ave, s} = makeA($this, i_T, i_S, i_N)
             let tdTextA, tdTextAve, textAve, textA;
-            if (nowA) {
+            if (hasNowA) {
                 let deltaB = calcDeltaB(a);
                 tdTextA = '<td class="border-0 border-b border-solid border-[--mt-line-color] p-0 " ' +
                     'align="center" data-from-calc="true" data-calc-a="' + deltaB + '" title="A: ' +

--- a/UserScript.js
+++ b/UserScript.js
@@ -423,12 +423,12 @@ function addDataCol() {
     }
 
     function addDataColGeneral() {
-        var i_T, i_S, i_N
+        let i_T, i_S, i_N;
         let calTHeadA = $("#calcTHeadA");
         let calTHeadAve = $("#calcTHeadAve");
-        let addFlag = calTHeadA.length !== 0 && calTHeadA.length !== 0;
+        let addFlag = calTHeadA.length !== 0 && calTHeadAve.length !== 0;
         $(seedTableSelector).each(function (row) {
-            var $this = $(this);
+            const $this = $(this);
             if (row == 0) {
                 $this.children('td').each(function (col) {
                     if ($(this).find('img.time').length) {
@@ -447,19 +447,19 @@ function addDataCol() {
                     }).showToast();
                     return
                 }
-                if (addFlag) {
-                    calTHeadA.html(aHeadText);
-                    calTHeadAve.html(aHeadText);
-                } else {
+                if (!addFlag) {
                     $this.children("td:last").before('<td class="colhead" style="cursor: pointer;" ' +
                         'id="calcTHeadA" title="' + aTitle + '">' + aHeadText + '</td>',
                         '<td class="colhead" style="cursor: pointer;" ' +
                         'id="calcTHeadAve" title="' + aveTitle + '">' + aveHeadText + '</td>');
-                    $('#calcTHeadA,#calcTHeadAve').off('click')
-                        .on('click', function () {
-                            handleSortTable(this.id);
-                        });
+                }else{
+                    $("#calcTHeadA").attr('title', aTitle);
+                    $("#calcTHeadAve").attr('title', aveTitle);
                 }
+                $('#calcTHeadA,#calcTHeadAve').off('click')
+                    .on('click', function () {
+                        handleSortTable(this.id);
+                    });
             } else {
                 let {a, ave, s} = makeA($this, i_T, i_S, i_N);
                 let textAve = makeTextAve(ave);
@@ -486,8 +486,6 @@ function addDataCol() {
     function addDataColMTeam() {
         let i_T, i_S, i_N, addFlag = false
 
-        console.log(nowA);
-
         let colLen = $('div.mt-4>table>thead>tr>th').length
         if ($('div.mt-4>table>thead>tr>th:last').attr('id') === "calcTHeadAve") {
             addFlag = true
@@ -502,11 +500,14 @@ function addDataCol() {
                     'style="width: 65px;cursor: pointer;" title="' + aTitle + '" id="calcTHeadA"> ' + aHeadText + ' </th>',
                     '<th class="border-0 border-b border-solid border-[--mt-line-color] p-2 " ' +
                     'style="width: 80px;cursor: pointer;" title="' + aveTitle + '" id="calcTHeadAve"> ' + aveHeadText + ' </th>');
-            $('#calcTHeadA,#calcTHeadAve').off('click')
-                .on('click', function () {
-                    handleSortTable(this.id);
-                });
+        } else {
+            $("#calcTHeadA").attr('title', aTitle);
+            $("#calcTHeadAve").attr('title', aveTitle);
         }
+        $('#calcTHeadA,#calcTHeadAve').off('click')
+            .on('click', function () {
+                handleSortTable(this.id);
+            });
         $(seedTableSelector).each(function (row) {
             const $this = $(this);
             let {a, ave, s} = makeA($this, i_T, i_S, i_N)

--- a/UserScript.js
+++ b/UserScript.js
@@ -331,15 +331,14 @@ function addDataCol(site) {
             $('div.mt-4>table>thead>tr>th:last')
                 .after("<th class=\"border-0 border-b border-solid border-[--mt-line-color] p-2 \" " +
                     "style=\"width: 100px;\" title=\"A值@每GB的A值\"> " +
-                "<div class=\"action\">A@A/GB</div>  </th>");
+                    "<div class=\"action\">A@A/GB</div>  </th>");
         }
         $(seedTableSelector).each(function (row) {
             var $this = $(this);
             var textA = makeA($this, i_T, i_S, i_N)
             // data-from-calc用于判断该元素是否由脚本生成
             let tdTextA = "<td class=\"border-0 border-b border-solid border-[--mt-line-color] p-0 \" " +
-                "align=\"center\" data-from-calc=\"true\">" +
-                + textA + "</td>"
+                "align=\"center\" data-from-calc=\"true\">" + textA + "</td>"
             if ($this.children("td:last").data("fromCalc")) {
                 $this.children("td:last").html(textA)
             } else {
@@ -358,42 +357,31 @@ function addDataCol(site) {
 
 function mTeamWaitPageLoadAndRun() {
     let $ = jQuery
-    let count = 0
-    let tableBlured = false
-    let T0Found = false
-    let seedTableFound = false
-    // 页面局部刷新后重新判断 isMybonusPage
-    isMybonusPage = window.location.toString().indexOf("mybonus") != -1
-    let itv = setInterval(() => {
-
+    let contentObserver = new MutationObserver((mutationsList, observer) => {
+        let T0Found = false;
+        let seedTableFound = false;
+        let isMybonusPage = window.location.toString().indexOf("mybonus") != -1
         if (isMybonusPage) {
-            T0Found = $("li:has(b:contains('T0'))")[1]
+            T0Found = $("li:has(b:contains('T0'))")[1];
         }
-        if (T0Found || seedTableFound || count >= 100) {
-            clearInterval(itv);
-            run()
-        }
-        count++
-    }, 100);
-
-    let count2 = 0
-    let itvTableBlur = setInterval(() => {
-        if ($('div.ant-spin-blur')[0] || count2 >= 50) {
-            tableBlured = true
-            clearInterval(itvTableBlur)
-        }
-        count2++
-    }, 100)
-    let count3 = 0
-    let itvTableUnblur = setInterval(() => {
-        if (tableBlured && !$('div.ant-spin-blur')[0] || count3 >= 100) {
-            seedTableFound = $(seedTableSelector)[1]
-            if (seedTableFound || count3 >= 100) {
-                clearInterval(itvTableUnblur)
+        if (T0Found) {
+            observer.disconnect();
+            run();
+        } else {
+            seedTableFound = $(seedTableSelector)[1];
+            if (seedTableFound) {
+                observer.disconnect();
+                run();
             }
         }
-        count3++
-    }, 100)
+    });
+    let bodyObserver = new MutationObserver((mutationsList, observer) => {
+        if (document.body) {
+            observer.disconnect();
+            contentObserver.observe(document.body, {childList: true, subtree: true});
+        }
+    });
+    bodyObserver.observe(document, {childList: true, subtree: true});
 }
 
 let host = window.location.host.match(/\b[^\.]+\.[^\.]+$/)[0]

--- a/UserScript.js
+++ b/UserScript.js
@@ -466,8 +466,8 @@ function addDataCol() {
                 if (nowA) {
                     let deltaB = calcDeltaB(a);
                     if (addFlag) {
-                        $this.children(":nth-last-child(2)").html(deltaB.toFixed(2));
-                        $this.children(":nth-last-child(3)").html((deltaB / s).toFixed(2));
+                        $this.children(":nth-last-child(3)").html(deltaB.toFixed(2));
+                        $this.children(":nth-last-child(2)").html((deltaB / s).toFixed(2));
                     } else {
                         $this.children("td:last").before('<td class="rowfollow" data-calc-a="' + deltaB + '" ' +
                             'title="A: ' + a.toFixed(2) + '">' + deltaB.toFixed(2) + '</td>',

--- a/UserScript.js
+++ b/UserScript.js
@@ -232,7 +232,7 @@ function addDataCol(site) {
     let B0 = GM_getValue(siteName + ".B0");
     let L = GM_getValue(siteName + ".L");
     if (!(T0 && N0 && B0 && L)) {
-        let bonusPageUrl = window.location.protocol + "//" + site.host[0] + site.bonusPage;
+        let bonusPageUrl = window.location.origin + site.bonusPage;
         Toastify({
             text: "请先访问 " + bonusPageUrl + " 以获取魔力值参数",
             destination: bonusPageUrl,

--- a/UserScript.js
+++ b/UserScript.js
@@ -446,39 +446,14 @@ function addDataCol() {
         let calTHeadA = $("#calcTHeadA");
         let calTHeadAve = $("#calcTHeadAve");
         let addFlag = calTHeadA.length !== 0 && calTHeadAve.length !== 0;
+        let thead = $(seedTableHeaderSelector);
+        if (thead.length > 0) {
+            detectAndAddHead(thead, "th");
+        }
         $(seedTableSelector).each(function (row) {
             const $this = $(this);
-            if (row == 0) {
-                $this.children('td').each(function (col) {
-                    if ($(this).find('img.time').length) {
-                        i_T = col
-                    } else if ($(this).find('img.size').length) {
-                        i_S = col
-                    } else if ($(this).find('img.seeders').length) {
-                        i_N = col
-                    }
-                })
-                if (!i_T || !i_S || !i_N) {
-                    Toastify({
-                        text: "未能找到数据列",
-                        duration: 3000,
-                        close: true
-                    }).showToast();
-                    return
-                }
-                if (!addFlag) {
-                    $this.children("td:last").before('<td class="colhead" style="cursor: pointer;" ' +
-                        'id="calcTHeadA" title="' + aTitle + '">' + aHeadText + '</td>',
-                        '<td class="colhead" style="cursor: pointer;" ' +
-                        'id="calcTHeadAve" title="' + aveTitle + '">' + aveHeadText + '</td>');
-                } else {
-                    $("#calcTHeadA").attr('title', aTitle);
-                    $("#calcTHeadAve").attr('title', aveTitle);
-                }
-                $('#calcTHeadA,#calcTHeadAve').off('click')
-                    .on('click', function () {
-                        handleSortTable(this.id);
-                    });
+            if (row === 0 && thead.length === 0) {
+                detectAndAddHead($this, "td");
             } else {
                 let {a, ave, s} = makeA($this, i_T, i_S, i_N);
                 let textAve = makeTextAve(ave);
@@ -504,6 +479,40 @@ function addDataCol() {
                 }
             }
         })
+
+        function detectAndAddHead(head, cellTag) {
+            head.children(cellTag).each(function (col) {
+                if ($(this).find('img.time').length) {
+                    i_T = col
+                } else if ($(this).find('img.size').length) {
+                    i_S = col
+                } else if ($(this).find('img.seeders').length) {
+                    i_N = col
+                }
+            })
+            if (!i_T || !i_S || !i_N) {
+                Toastify({
+                    text: "未能找到数据列",
+                    duration: 3000,
+                    close: true
+                }).showToast();
+                return
+            }
+            if (!addFlag) {
+                head.children(cellTag + ":last").before('<' + cellTag + ' class="colhead" style="cursor: pointer;" ' +
+                    'id="calcTHeadA" title="' + aTitle + '">' + aHeadText + '</' + cellTag + '>',
+                    '<' + cellTag + ' class="colhead" style="cursor: pointer;" ' +
+                    'id="calcTHeadAve" title="' + aveTitle + '">' + aveHeadText + '</' + cellTag + '>');
+            } else {
+                $("#calcTHeadA").attr('title', aTitle);
+                $("#calcTHeadAve").attr('title', aveTitle);
+            }
+            $('#calcTHeadA,#calcTHeadAve').off('click')
+                .on('click', function () {
+                    handleSortTable(this.id);
+                });
+        }
+
         sortTable();
     }
 
@@ -604,9 +613,12 @@ function addDataCol() {
         if (isMTeam) {
             rows = $tbody.children('tr').toArray();
         } else {
-            rows = $tbody.children('tr')
-                .not(':first-child')        // 排除表头行
-                .toArray();
+           let $rows = $tbody.children('tr');
+            if ($(seedTableHeaderSelector).length === 0) {
+                // 如果站点将表头也放在tbody中，则排除第一行
+                $rows = $rows.not(':first-child')
+            }
+            rows = $rows.toArray();
         }
         // 保存原始顺序
         if (needStore) {
@@ -669,6 +681,7 @@ function mTeamWaitPageLoadAndRun() {
 let host = window.location.host.match(/\b[^\.]+\.[^\.]+$/)[0]
 let isMTeam = window.location.toString().indexOf("m-team") != -1
 let mTeamUrl
+let seedTableHeaderSelector = '.torrents:last-of-type>thead>tr';
 let seedTableSelector = isMTeam ? 'div.ant-spin-container:not(.ant-spin-blur)>div.mt-4>table>tbody>tr' : '.torrents:last-of-type>tbody>tr'
 let isMybonusPage = window.location.toString().indexOf("mybonus") != -1
 if (isMTeam) {

--- a/UserScript.js
+++ b/UserScript.js
@@ -170,12 +170,9 @@ function drawChart(bonusParams) {
                 type: 'cross'
             },
             backgroundColor: 'rgba(255, 255, 255, 0.8)',
-            position: function (pos, params, el, elRect, size) {
-                var obj = {top: 10};
-                obj[['left', 'right'][+(pos[0] < size.viewSize[0] / 2)]] = 30;
-                return obj;
-            },
-            extraCssText: 'width: 170px'
+            valueFormatter: function (value) {
+                return value.toFixed(2);
+            }
         },
         xAxis: {
             name: 'A',
@@ -192,7 +189,7 @@ function drawChart(bonusParams) {
             {
                 type: 'line',
                 data: data,
-                symbol: 'none'
+                showSymbol: false
             },
             {
                 type: 'line',

--- a/UserScript.js
+++ b/UserScript.js
@@ -296,7 +296,6 @@ function addDataCol(site) {
             var $this = $(this);
             if (row == 0) {
                 $this.children('td').each(function (col) {
-
                     if ($(this).find('img.time').length) {
                         i_T = col
                     } else if ($(this).find('img.size').length) {
@@ -329,15 +328,19 @@ function addDataCol(site) {
         i_S = colLen - 4
         i_N = colLen - 3
         if (!addFlag) {
-            $('div.mt-4>table>thead>tr>th:last').after("<th class=\"border-0 border-b border-solid border-[--mt-line-color] p-2 \" style=\"width: 100px;\" title=\"A值@每GB的A值\"> " +
+            $('div.mt-4>table>thead>tr>th:last')
+                .after("<th class=\"border-0 border-b border-solid border-[--mt-line-color] p-2 \" " +
+                    "style=\"width: 100px;\" title=\"A值@每GB的A值\"> " +
                 "<div class=\"action\">A@A/GB</div>  </th>");
         }
         $(seedTableSelector).each(function (row) {
             var $this = $(this);
             var textA = makeA($this, i_T, i_S, i_N)
-            let tdTextA = "<td class=\"border-0 border-b border-solid border-[--mt-line-color] p-0 \" align=\"center\">"
+            // data-from-calc用于判断该元素是否由脚本生成
+            let tdTextA = "<td class=\"border-0 border-b border-solid border-[--mt-line-color] p-0 \" " +
+                "align=\"center\" data-from-calc=\"true\">" +
                 + textA + "</td>"
-            if (addFlag) {
+            if ($this.children("td:last").data("fromCalc")) {
                 $this.children("td:last").html(textA)
             } else {
                 $this.children("td:last").after(tdTextA)

--- a/UserScript.js
+++ b/UserScript.js
@@ -450,7 +450,7 @@ function mTeamWaitPageLoadAndRun() {
 
 let host = window.location.host.match(/\b[^\.]+\.[^\.]+$/)[0]
 let isMTeam = window.location.toString().indexOf("m-team") != -1
-let seedTableSelector = isMTeam ? 'div.mt-4>table>tbody>tr' : '.torrents:last-of-type>tbody>tr'
+let seedTableSelector = isMTeam ? 'div.ant-spin-container:not(.ant-spin-blur)>div.mt-4>table>tbody>tr' : '.torrents:last-of-type>tbody>tr'
 let isMybonusPage = window.location.toString().indexOf("mybonus") != -1
 if (window.location.toString().indexOf("tjupt.org") != -1) {
     isMybonusPage = window.location.toString().indexOf("bonus.php") != -1


### PR DESCRIPTION
重构代码，将获取魔力值参数、绘制B-A图、添加数据列单独成不同的函数。
添加siteInfo对站点进行管理，存储数据时以站点名为键，避免同一个站点使用不同的域名需要再次获取参数。
对M-Team的种子页使用MutationObserver替换原轮询，以更快显示数据。
使用Toastify-js替代alert，避免alert中断浏览。