### PR TITLE
增强 M-Team 解析并扩展健康 PT 站点匹配

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@
 
 ![](https://s2.loli.net/2022/02/04/kLu13N2l87zYTBa.png)
 
+### 支持范围与适配说明
+
+当前脚本已将 [PT监护室](https://savept.icu/) 中标记为“健康”的 140 个 PT 站点加入匹配规则，并同时覆盖主域名和子域名的 `torrents*` 页面。
+
+需要注意：加入匹配规则只代表脚本会在这些站点页面注入，不代表每个站点都已经完成表格结构适配。普通站点仍主要按 NexusPHP 类种子列表解析；如果站点使用了非标准表格、前端重构页面、不同的时间/体积/做种人数列结构，可能需要单独适配。
+
+M-Team 已做单独适配，覆盖：
+
+- `kp.m-team.cc`
+- `zp.m-team.io`
+
+M-Team 的 `/mybonus` 页面参数提取已支持新版文本结构，例如 `T0為參數。T0 = 4`、`N0 = 7`、`B0 = 50`、`L = 300`。
+
 ### 使用
 
 脚本安装：https://greasyfork.org/en/scripts/439369-pt站点魔力计算器
@@ -27,11 +40,11 @@
 
 ### 参与开发
 
-https://github.com/neoblackxt/PTMyBonusCalc
+https://github.com/huoyart/PTMyBonusCalc
 
 ### 问题反馈
 
-https://github.com/neoblackxt/PTMyBonusCalc/issues
+https://github.com/huoyart/PTMyBonusCalc/issues
 
 请将不支持的站点的种子列表和魔力值网页源代码粘贴在issue中，**注意把你的网站ID信息以及其他敏感信息删除，但不要破环网页结构** 不知道怎么删除请不要发出来（Ctrl + U 查看网页源代码，Ctrl + S 保存文件）。
 

--- a/UserScript.js
+++ b/UserScript.js
@@ -6,34 +6,291 @@
 // @author       neoblackxt, LaneLau
 // @require      https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js
 // @require      https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js
-// @match        *://*.beitai.pt/torrents*
-// @match        *://*.pttime.org/torrents*
-// @match        *://*.ptsbao.club/torrents*
-// @match        *://*.pthome.net/torrents*
 // @match        *://kp.m-team.cc/*
 // @match        *://zp.m-team.io/*
-// @match        *://*.hddolby.com/torrents*
-// @match        *://*.leaguehd.com/torrents*
-// @match        *://*.hdhome.org/torrents*
-// @match        *://*.hdsky.me/torrents*
-// @match        *://*.ourbits.club/torrents*
-// @match        *://*.u2.dmhy.org/torrents*
-// @match        *://*.hdzone.me/torrents*
-// @match        *://*.hdatmos.club/torrents*
-// @match        *://*.pt.soulvoice.club/torrents*
-// @match        *://*.pt.soulvoice.club/live*
-// @match        *://*.discfan.net/torrents*
-// @match        *://*.hdtime.org/torrents*
-// @match        *://*.nicept.net/torrents*
-// @match        *://*.pterclub.com/torrents*
-// @match        *://*.hdarea.co/torrents*
-// @match        *://*.hdfans.org/torrents*
-// @match        *://pt.btschool.club/torrents*
+// @match        *://13city.org/torrents*
+// @match        *://*.13city.org/torrents*
+// @match        *://1ptba.com/torrents*
 // @match        *://*.1ptba.com/torrents*
-// @match        *://www.oshen.win/torrents*
-// @match        *://*.rousi.zip/torrents*
+// @match        *://52movie.top/torrents*
+// @match        *://*.52movie.top/torrents*
+// @match        *://52pt.site/torrents*
+// @match        *://*.52pt.site/torrents*
+// @match        *://aither.cc/torrents*
+// @match        *://*.aither.cc/torrents*
+// @match        *://alpharatio.cc/torrents*
+// @match        *://*.alpharatio.cc/torrents*
+// @match        *://animez.to/torrents*
+// @match        *://*.animez.to/torrents*
+// @match        *://anthelion.me/torrents*
+// @match        *://*.anthelion.me/torrents*
+// @match        *://audiences.me/torrents*
+// @match        *://*.audiences.me/torrents*
+// @match        *://azusa.wiki/torrents*
+// @match        *://*.azusa.wiki/torrents*
+// @match        *://beyond-hd.me/torrents*
+// @match        *://*.beyond-hd.me/torrents*
+// @match        *://bilibili.download/torrents*
+// @match        *://*.bilibili.download/torrents*
+// @match        *://bitporn.eu/torrents*
+// @match        *://*.bitporn.eu/torrents*
+// @match        *://brokenstones.is/torrents*
+// @match        *://*.brokenstones.is/torrents*
+// @match        *://cangbao.ge/torrents*
+// @match        *://*.cangbao.ge/torrents*
+// @match        *://carpt.net/torrents*
+// @match        *://*.carpt.net/torrents*
+// @match        *://clearjav.com/torrents*
+// @match        *://*.clearjav.com/torrents*
+// @match        *://crabpt.vip/torrents*
+// @match        *://*.crabpt.vip/torrents*
+// @match        *://cspt.top/torrents*
+// @match        *://*.cspt.top/torrents*
+// @match        *://cyanbug.net/torrents*
+// @match        *://*.cyanbug.net/torrents*
+// @match        *://dicmusic.com/torrents*
+// @match        *://*.dicmusic.com/torrents*
+// @match        *://discfan.net/torrents*
+// @match        *://*.discfan.net/torrents*
+// @match        *://dragonhd.xyz/torrents*
+// @match        *://*.dragonhd.xyz/torrents*
+// @match        *://dstudio.me/torrents*
+// @match        *://*.dstudio.me/torrents*
+// @match        *://dubhe.site/torrents*
+// @match        *://*.dubhe.site/torrents*
+// @match        *://duckboobee.org/torrents*
+// @match        *://*.duckboobee.org/torrents*
+// @match        *://empornium.sx/torrents*
+// @match        *://*.empornium.sx/torrents*
+// @match        *://et8.org/torrents*
+// @match        *://*.et8.org/torrents*
+// @match        *://exoticaz.to/torrents*
+// @match        *://*.exoticaz.to/torrents*
+// @match        *://fappaizuri.me/torrents*
+// @match        *://*.fappaizuri.me/torrents*
+// @match        *://fearnopeer.com/torrents*
+// @match        *://*.fearnopeer.com/torrents*
+// @match        *://filelist.io/torrents*
+// @match        *://*.filelist.io/torrents*
+// @match        *://gamegamept.com/torrents*
+// @match        *://*.gamegamept.com/torrents*
+// @match        *://generation-free.org/torrents*
+// @match        *://*.generation-free.org/torrents*
+// @match        *://greatposterwall.com/torrents*
+// @match        *://*.greatposterwall.com/torrents*
+// @match        *://haidan.cc/torrents*
+// @match        *://*.haidan.cc/torrents*
+// @match        *://happyfappy.net/torrents*
+// @match        *://*.happyfappy.net/torrents*
+// @match        *://hawke.uno/torrents*
+// @match        *://*.hawke.uno/torrents*
+// @match        *://hdarea.club/torrents*
+// @match        *://*.hdarea.club/torrents*
+// @match        *://hdbao.cc/torrents*
+// @match        *://*.hdbao.cc/torrents*
+// @match        *://hdcity.city/torrents*
+// @match        *://*.hdcity.city/torrents*
+// @match        *://hddolby.com/torrents*
+// @match        *://*.hddolby.com/torrents*
+// @match        *://hdfans.org/torrents*
+// @match        *://*.hdfans.org/torrents*
+// @match        *://hdhome.org/torrents*
+// @match        *://*.hdhome.org/torrents*
+// @match        *://hdkyl.in/torrents*
+// @match        *://*.hdkyl.in/torrents*
+// @match        *://hdsky.me/torrents*
+// @match        *://*.hdsky.me/torrents*
+// @match        *://hdtime.org/torrents*
+// @match        *://*.hdtime.org/torrents*
+// @match        *://hd-torrents.org/torrents*
+// @match        *://*.hd-torrents.org/torrents*
+// @match        *://hdvideo.top/torrents*
+// @match        *://*.hdvideo.top/torrents*
+// @match        *://hhanclub.net/torrents*
+// @match        *://*.hhanclub.net/torrents*
+// @match        *://hitpt.com/torrents*
+// @match        *://*.hitpt.com/torrents*
+// @match        *://htpt.cc/torrents*
+// @match        *://*.htpt.cc/torrents*
+// @match        *://hxpt.org/torrents*
+// @match        *://*.hxpt.org/torrents*
+// @match        *://iptorrents.com/torrents*
+// @match        *://*.iptorrents.com/torrents*
+// @match        *://jpopsuki.eu/torrents*
+// @match        *://*.jpopsuki.eu/torrents*
+// @match        *://kamept.com/torrents*
+// @match        *://*.kamept.com/torrents*
+// @match        *://kp.m-team.cc/torrents*
+// @match        *://*.kp.m-team.cc/torrents*
+// @match        *://kufei.org/torrents*
 // @match        *://*.kufei.org/torrents*
+// @match        *://lemonhd.net/torrents*
+// @match        *://*.lemonhd.net/torrents*
+// @match        *://longpt.org/torrents*
+// @match        *://*.longpt.org/torrents*
+// @match        *://lst.gg/torrents*
+// @match        *://*.lst.gg/torrents*
+// @match        *://milkie.cc/torrents*
+// @match        *://*.milkie.cc/torrents*
+// @match        *://momentpt.top/torrents*
+// @match        *://*.momentpt.top/torrents*
+// @match        *://monikadesign.uk/torrents*
+// @match        *://*.monikadesign.uk/torrents*
+// @match        *://morethantv.me/torrents*
+// @match        *://*.morethantv.me/torrents*
+// @match        *://mua.xloli.cc/torrents*
+// @match        *://*.mua.xloli.cc/torrents*
+// @match        *://musopia.vip/torrents*
+// @match        *://*.musopia.vip/torrents*
+// @match        *://myanonamouse.net/torrents*
+// @match        *://*.myanonamouse.net/torrents*
+// @match        *://nanyangpt.com/torrents*
+// @match        *://*.nanyangpt.com/torrents*
+// @match        *://nebulance.io/torrents*
+// @match        *://*.nebulance.io/torrents*
+// @match        *://nicept.net/torrents*
+// @match        *://*.nicept.net/torrents*
+// @match        *://njtupt.top/torrents*
+// @match        *://*.njtupt.top/torrents*
+// @match        *://okpt.net/torrents*
+// @match        *://*.okpt.net/torrents*
+// @match        *://open.cd/torrents*
+// @match        *://*.open.cd/torrents*
+// @match        *://orpheus.network/torrents*
+// @match        *://*.orpheus.network/torrents*
+// @match        *://our.kelu.one/torrents*
+// @match        *://*.our.kelu.one/torrents*
+// @match        *://ourbits.club/torrents*
+// @match        *://*.ourbits.club/torrents*
+// @match        *://p.t-baozi.cc/torrents*
+// @match        *://*.p.t-baozi.cc/torrents*
+// @match        *://pandapt.net/torrents*
+// @match        *://*.pandapt.net/torrents*
+// @match        *://piggo.me/torrents*
+// @match        *://*.piggo.me/torrents*
+// @match        *://playlet.cc/torrents*
+// @match        *://*.playlet.cc/torrents*
+// @match        *://pt.0ff.cc/torrents*
+// @match        *://*.pt.0ff.cc/torrents*
+// @match        *://pt.agsvpt.cn/torrents*
+// @match        *://*.pt.agsvpt.cn/torrents*
+// @match        *://pt.aling.de/torrents*
+// @match        *://*.pt.aling.de/torrents*
+// @match        *://pt.btschool.club/torrents*
+// @match        *://*.pt.btschool.club/torrents*
+// @match        *://pt.cdy.skin/torrents*
+// @match        *://*.pt.cdy.skin/torrents*
+// @match        *://pt.eastgame.org/torrents*
+// @match        *://*.pt.eastgame.org/torrents*
+// @match        *://pt.gtkpw.xyz/torrents*
+// @match        *://*.pt.gtkpw.xyz/torrents*
+// @match        *://pt.hdclone.top/torrents*
+// @match        *://*.pt.hdclone.top/torrents*
+// @match        *://pt.hdupt.com/torrents*
+// @match        *://*.pt.hdupt.com/torrents*
+// @match        *://pt.itzmx.com/torrents*
+// @match        *://*.pt.itzmx.com/torrents*
+// @match        *://pt.keepfrds.com/torrents*
+// @match        *://*.pt.keepfrds.com/torrents*
+// @match        *://pt.lajidui.top/torrents*
+// @match        *://*.pt.lajidui.top/torrents*
+// @match        *://pt.luckpt.de/torrents*
+// @match        *://*.pt.luckpt.de/torrents*
+// @match        *://pt.muxuege.org/torrents*
+// @match        *://*.pt.muxuege.org/torrents*
+// @match        *://pt.mypt.cc/torrents*
+// @match        *://*.pt.mypt.cc/torrents*
+// @match        *://pt.sjtu.edu.cn/torrents*
+// @match        *://*.pt.sjtu.edu.cn/torrents*
+// @match        *://pt.soulvoice.club/torrents*
+// @match        *://*.pt.soulvoice.club/torrents*
+// @match        *://pt.tey.cc/torrents*
+// @match        *://*.pt.tey.cc/torrents*
+// @match        *://pt.tu88.men/torrents*
+// @match        *://*.pt.tu88.men/torrents*
+// @match        *://pt.xingyungept.org/torrents*
+// @match        *://*.pt.xingyungept.org/torrents*
+// @match        *://pt.ying.us.kg/torrents*
+// @match        *://*.pt.ying.us.kg/torrents*
+// @match        *://ptcafe.club/torrents*
+// @match        *://*.ptcafe.club/torrents*
+// @match        *://ptchdbits.co/torrents*
+// @match        *://*.ptchdbits.co/torrents*
+// @match        *://pterclub.net/torrents*
+// @match        *://*.pterclub.net/torrents*
+// @match        *://ptfans.cc/torrents*
+// @match        *://*.ptfans.cc/torrents*
+// @match        *://pthome.net/torrents*
+// @match        *://*.pthome.net/torrents*
+// @match        *://ptlao.top/torrents*
+// @match        *://*.ptlao.top/torrents*
+// @match        *://ptlgs.org/torrents*
+// @match        *://*.ptlgs.org/torrents*
+// @match        *://ptsbao.club/torrents*
+// @match        *://*.ptsbao.club/torrents*
+// @match        *://ptskit.org/torrents*
+// @match        *://*.ptskit.org/torrents*
+// @match        *://pttime.org/torrents*
+// @match        *://*.pttime.org/torrents*
+// @match        *://ptzone.xyz/torrents*
+// @match        *://*.ptzone.xyz/torrents*
+// @match        *://qingwapt.com/torrents*
+// @match        *://*.qingwapt.com/torrents*
+// @match        *://raingfh.top/torrents*
+// @match        *://*.raingfh.top/torrents*
+// @match        *://rousi.pro/torrents*
+// @match        *://*.rousi.pro/torrents*
+// @match        *://sbpt.link/torrents*
+// @match        *://*.sbpt.link/torrents*
+// @match        *://sewerpt.com/torrents*
+// @match        *://*.sewerpt.com/torrents*
+// @match        *://si-qi.xyz/torrents*
+// @match        *://*.si-qi.xyz/torrents*
+// @match        *://sportscult.org/torrents*
+// @match        *://*.sportscult.org/torrents*
+// @match        *://springsunday.net/torrents*
+// @match        *://*.springsunday.net/torrents*
+// @match        *://star-space.net/torrents*
+// @match        *://*.star-space.net/torrents*
+// @match        *://sunnypt.top/torrents*
+// @match        *://*.sunnypt.top/torrents*
+// @match        *://tangpt.top/torrents*
+// @match        *://*.tangpt.top/torrents*
+// @match        *://tjupt.org/torrents*
 // @match        *://*.tjupt.org/torrents*
+// @match        *://tokyo-manga.top/torrents*
+// @match        *://*.tokyo-manga.top/torrents*
+// @match        *://torrentleech.cc/torrents*
+// @match        *://*.torrentleech.cc/torrents*
+// @match        *://totheglory.im/torrents*
+// @match        *://*.totheglory.im/torrents*
+// @match        *://tracker.novahd.top/torrents*
+// @match        *://*.tracker.novahd.top/torrents*
+// @match        *://u2.dmhy.org/torrents*
+// @match        *://*.u2.dmhy.org/torrents*
+// @match        *://ubits.club/torrents*
+// @match        *://*.ubits.club/torrents*
+// @match        *://ultrahd.net/torrents*
+// @match        *://*.ultrahd.net/torrents*
+// @match        *://web.yemapt.org/torrents*
+// @match        *://*.web.yemapt.org/torrents*
+// @match        *://wintersakura.net/torrents*
+// @match        *://*.wintersakura.net/torrents*
+// @match        *://xingtan.one/torrents*
+// @match        *://*.xingtan.one/torrents*
+// @match        *://xingwan.cc/torrents*
+// @match        *://*.xingwan.cc/torrents*
+// @match        *://yhpp.cc/torrents*
+// @match        *://*.yhpp.cc/torrents*
+// @match        *://zhuque.in/torrents*
+// @match        *://*.zhuque.in/torrents*
+// @match        *://zmpt.cc/torrents*
+// @match        *://*.zmpt.cc/torrents*
+// @match        *://zrpt.cc/torrents*
+// @match        *://*.zrpt.cc/torrents*
+// @match        *://pt.soulvoice.club/live*
+// @match        *://*.pt.soulvoice.club/live*
+// @match        *://tjupt.org/bonus*
 // @match        *://*.tjupt.org/bonus*
 // @match        *://*/mybonus*
 // @license      GPL License
@@ -50,6 +307,87 @@ const colorsOfAVE = [
     {min: 1.5, max: 2, color: '#8B4513', fontWeight: 800}, // 棕色
     {min: 2, max: Infinity, color: '#ff0000', fontWeight: 900} // 红色
 ]
+
+function extractBonusParam(text, name, allowLoose = true) {
+    if (!text) {
+        return undefined
+    }
+    let normalized = text.replace(/\s+/g, ' ')
+    let escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    let strictReg = new RegExp('(?:^|[^A-Za-z0-9])' + escapedName + '(?![A-Za-z0-9])\\s*(?:=|:|：)\\s*(\\d+(?:\\.\\d+)?)', 'i')
+    let strictMatch = normalized.match(strictReg)
+    if (strictMatch) {
+        return parseFloat(strictMatch[1])
+    }
+
+    if (!allowLoose || normalized.length > 120) {
+        return undefined
+    }
+    let looseReg = new RegExp('(?:^|[^A-Za-z0-9])' + escapedName + '(?![A-Za-z0-9])\\s+(\\d+(?:\\.\\d+)?)', 'i')
+    let looseMatch = normalized.match(looseReg)
+    return looseMatch ? parseFloat(looseMatch[1]) : undefined
+}
+
+function getBonusParamFromPage(name) {
+    let nodes = document.querySelectorAll('li, div, p, span, td, th, tr')
+    for (let node of nodes) {
+        let value = extractBonusParam(node.innerText, name)
+        if (Number.isFinite(value)) {
+            return value
+        }
+    }
+    return extractBonusParam(document.body ? document.body.innerText : '', name, false)
+}
+
+function getBonusParamsFromPage() {
+    return {
+        T0: getBonusParamFromPage('T0'),
+        N0: getBonusParamFromPage('N0'),
+        B0: getBonusParamFromPage('B0'),
+        L: getBonusParamFromPage('L')
+    }
+}
+
+function parseFirstNumber(text) {
+    let match = (text || '').replace(/,/g, '').match(/\d+(?:\.\d+)?/)
+    return match ? parseFloat(match[0]) : undefined
+}
+
+function getMTeamBasicBonus($) {
+    let basicBonus;
+    $("td:contains('基本獎勵')").each(function () {
+        if (Number.isFinite(basicBonus)) {
+            return false
+        }
+        let oldLayoutValue = parseFirstNumber($(this).next('td').next('td').text())
+        if (Number.isFinite(oldLayoutValue)) {
+            basicBonus = oldLayoutValue
+            return false
+        }
+        let values = $(this).nextAll('td').map(function () {
+            return parseFirstNumber($(this).text())
+        }).get().filter(Number.isFinite)
+        if (values.length) {
+            basicBonus = values[0]
+        }
+    });
+    return basicBonus
+}
+
+function getMTeamSeedingBonusRule() {
+    let text = document.body ? document.body.innerText.replace(/\s+/g, ' ') : ''
+    let match = text.match(/(\d+(?:\.\d+)?)\s*個魔力值\s*\*\s*你的做種數.*?最多計\s*(\d+)\s*個/)
+    return match ? {
+        perSeed: parseFloat(match[1]),
+        limit: parseInt(match[2])
+    } : undefined
+}
+
+function getMTeamCurrentSeeding() {
+    let text = document.body ? document.body.innerText.replace(/\s+/g, ' ') : ''
+    let match = text.match(/當前活動\s*[:：]\s*(\d+)/)
+    return match ? parseInt(match[1]) : undefined
+}
 
 function run() {
     var $ = jQuery;
@@ -69,10 +407,14 @@ function run() {
     if (isMybonusPage) {
 
         try {
-            T0 = parseInt($("li:has(b:contains('T0'))")[1].innerText.split(" = ")[1]);
-            N0 = parseInt($("li:has(b:contains('N0'))")[1].innerText.split(" = ")[1]);
-            B0 = parseInt($("li:has(b:contains('B0'))")[1].innerText.split(" = ")[1]);
-            L = parseInt($("li:has(b:contains('L'))")[1].innerText.split(" = ")[1]);
+            let params = getBonusParamsFromPage();
+            if (!(params.T0 && params.N0 && params.B0 && params.L)) {
+                throw new Error("未在页面文本中找到完整的 T0/N0/B0/L 参数");
+            }
+            T0 = params.T0;
+            N0 = params.N0;
+            B0 = params.B0;
+            L = params.L;
             console.log('数据提取成功:', T0, N0, B0, L);
         } catch (error) {
             console.error('数据提取过程中出现错误:', error);
@@ -109,18 +451,17 @@ function run() {
         }
 
         let A = isMTeam ? 0 : parseFloat($("div:contains(' (A = ')")[0].innerText.split(" = ")[1]);
-        let B = isMTeam ? parseFloat($("td:contains('基本獎勵')+td+td")[0].innerText) : calcB(A);
+        let B = isMTeam ? getMTeamBasicBonus($) : calcB(A);
+        if (isMTeam && !Number.isFinite(B)) {
+            alert("未找到M-Team基本獎勵，无法绘制 B-A 图");
+            return
+        }
         // 剔除M-Team的基本奖励中做种数奖励
         if (isMTeam) {
-            let matches = $("h5:contains('做種每小時將得到如下的魔力值')").next().children().first().text()
-                .match(/(\d+(\.\d+)?)個魔力值.*最多計(\d+)個/);
-            let seedingBonusPerSeed = parseFloat(matches[1]);
-            let seedingBonusLimit = parseInt(matches[3]);
-            let currentSeedingNode = $("span:contains('當前活動')").parent().clone();
-            currentSeedingNode.find('img').replaceWith(function () {
-                return "img";
-            });
-            let currentSeeding = parseInt(currentSeedingNode.text().match(/(\d+)/)[1]);
+            let seedingBonusRule = getMTeamSeedingBonusRule();
+            let seedingBonusPerSeed = seedingBonusRule ? seedingBonusRule.perSeed : 0;
+            let seedingBonusLimit = seedingBonusRule ? seedingBonusRule.limit : 0;
+            let currentSeeding = getMTeamCurrentSeeding() || 0;
             B = B - (currentSeeding > seedingBonusLimit ?
                 seedingBonusPerSeed * seedingBonusLimit : seedingBonusPerSeed * currentSeeding);
         }
@@ -330,7 +671,7 @@ function MTteamWaitPageLoadAndRun() {
     let itv = setInterval(() => {
 
         if (isMybonusPage) {
-            T0Found = $("li:has(b:contains('T0'))")[1]
+            T0Found = Number.isFinite(getBonusParamFromPage('T0'))
 
         }
         if (T0Found || seedTableFound || count >= 100) {

--- a/UserScript.js
+++ b/UserScript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PT站点魔力计算器
 // @namespace    https://github.com/neoblackxt/PTMyBonusCalc
-// @version      2.2.0
+// @version      2.2.1
 // @description  在使用NexusPHP架构的PT站点显示每个种子的A值和每GB的A值。
 // @author       neoblackxt, LaneLau
 // @require      https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js
@@ -180,6 +180,8 @@
 // @match        *://*.pt.0ff.cc/torrents*
 // @match        *://pt.agsvpt.cn/torrents*
 // @match        *://*.pt.agsvpt.cn/torrents*
+// @match        *://agsvpt.com/torrents*
+// @match        *://*.agsvpt.com/torrents*
 // @match        *://pt.aling.de/torrents*
 // @match        *://*.pt.aling.de/torrents*
 // @match        *://pt.btschool.club/torrents*
@@ -242,6 +244,8 @@
 // @match        *://*.ptzone.xyz/torrents*
 // @match        *://qingwapt.com/torrents*
 // @match        *://*.qingwapt.com/torrents*
+// @match        *://qingwapt.com/mybonus*
+// @match        *://*.qingwapt.com/mybonus*
 // @match        *://raingfh.top/torrents*
 // @match        *://*.raingfh.top/torrents*
 // @match        *://rousi.pro/torrents*

--- a/UserScript.js
+++ b/UserScript.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PT站点魔力计算器
 // @namespace    https://github.com/neoblackxt/PTMyBonusCalc
-// @version      2.1.0
+// @version      2.2.0
 // @description  在使用NexusPHP架构的PT站点显示每个种子的A值和每GB的A值。
 // @author       neoblackxt, LaneLau
 // @require      https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js
@@ -26,6 +26,8 @@
 // @match        *://*.anthelion.me/torrents*
 // @match        *://audiences.me/torrents*
 // @match        *://*.audiences.me/torrents*
+// @match        *://audiences.me/mybonus*
+// @match        *://*.audiences.me/mybonus*
 // @match        *://azusa.wiki/torrents*
 // @match        *://*.azusa.wiki/torrents*
 // @match        *://beyond-hd.me/torrents*
@@ -86,6 +88,8 @@
 // @match        *://*.hawke.uno/torrents*
 // @match        *://hdarea.club/torrents*
 // @match        *://*.hdarea.club/torrents*
+// @match        *://hdarea.club/mybonus*
+// @match        *://*.hdarea.club/mybonus*
 // @match        *://hdbao.cc/torrents*
 // @match        *://*.hdbao.cc/torrents*
 // @match        *://hdcity.city/torrents*
@@ -108,6 +112,8 @@
 // @match        *://*.hdvideo.top/torrents*
 // @match        *://hhanclub.net/torrents*
 // @match        *://*.hhanclub.net/torrents*
+// @match        *://hhanclub.net/mybonus*
+// @match        *://*.hhanclub.net/mybonus*
 // @match        *://hitpt.com/torrents*
 // @match        *://*.hitpt.com/torrents*
 // @match        *://htpt.cc/torrents*
@@ -348,6 +354,31 @@ function getBonusParamsFromPage() {
     }
 }
 
+function getSiteKey() {
+    return (window.location.hostname || window.location.host || '').replace(/^www\./, '')
+}
+
+function getLegacySiteKey() {
+    let match = (window.location.host || '').match(/\b[^\.]+\.[^\.]+$/)
+    return match ? match[0] : getSiteKey()
+}
+
+function getStoredParam(name) {
+    let value = GM_getValue(host + "." + name)
+    if (!value && legacyHost && legacyHost !== host) {
+        value = GM_getValue(legacyHost + "." + name)
+    }
+    return value
+}
+
+function setStoredParam(name, value) {
+    GM_setValue(host + "." + name, value)
+}
+
+function isBonusParamPage() {
+    return /\/(?:mybonus|bonus)(?:\.php)?(?:[?#/]|$)/i.test(window.location.pathname)
+}
+
 function parseFirstNumber(text) {
     let match = (text || '').replace(/,/g, '').match(/\d+(?:\.\d+)?/)
     return match ? parseFloat(match[0]) : undefined
@@ -389,15 +420,88 @@ function getMTeamCurrentSeeding() {
     return match ? parseInt(match[1]) : undefined
 }
 
+function getCellSignature($cell) {
+    let imageMeta = $cell.find('img').map(function () {
+        return [
+            this.className,
+            this.alt,
+            this.title,
+            this.src
+        ].join(' ')
+    }).get().join(' ')
+    return [
+        $cell.text(),
+        $cell.attr('title'),
+        imageMeta,
+        $cell.html()
+    ].join(' ').toLowerCase()
+}
+
+function detectTorrentColumns($headerRow) {
+    let columns = {time: null, size: null, seeders: null}
+    $headerRow.children('td,th').each(function (col) {
+        let $cell = jQuery(this)
+        let sig = getCellSignature($cell)
+        if (columns.time == null && (
+            $cell.find('img.time').length ||
+            /\btime\b|added|date|publish|發布|发布|時間|时间/.test(sig)
+        )) {
+            columns.time = col
+        } else if (columns.size == null && (
+            $cell.find('img.size').length ||
+            /\bsize\b|大小|體積|体积/.test(sig)
+        )) {
+            columns.size = col
+        } else if (columns.seeders == null && (
+            $cell.find('img.seeders').length ||
+            /seeders?|做種|做种|做種者|做种者|種子數|种子数/.test(sig)
+        )) {
+            columns.seeders = col
+        }
+    })
+    return columns
+}
+
+function getGeneralSeedRows($) {
+    let selectors = [
+        '.torrents:last-of-type>tbody>tr',
+        'table.torrents:last-of-type>tbody>tr',
+        'table#torrent_table>tbody>tr',
+        'table[class*="torrent"]:last-of-type>tbody>tr'
+    ]
+    for (let selector of selectors) {
+        let rows = $(selector)
+        if (rows.length > 1) {
+            return rows
+        }
+    }
+
+    let bestRows = $()
+    $('table').each(function () {
+        let rows = $(this).find('tbody>tr')
+        if (rows.length <= 1) {
+            rows = $(this).find('tr')
+        }
+        if (rows.length <= 1) {
+            return
+        }
+        let columns = detectTorrentColumns(rows.first())
+        if (columns.time != null && columns.size != null && columns.seeders != null) {
+            bestRows = rows
+        }
+    })
+    return bestRows
+}
+
 function run() {
     var $ = jQuery;
 
 
     let argsReady = true;
-    let T0 = GM_getValue(host + ".T0");
-    let N0 = GM_getValue(host + ".N0");
-    let B0 = GM_getValue(host + ".B0");
-    let L = GM_getValue(host + ".L");
+    let T0 = getStoredParam("T0");
+    let N0 = getStoredParam("N0");
+    let B0 = getStoredParam("B0");
+    let L = getStoredParam("L");
     if (!(T0 && N0 && B0 && L)) {
         argsReady = false
         if (!isMybonusPage) {
@@ -429,10 +533,10 @@ function run() {
                 alert("魔力值参数获取失败,请将Tampermonkey的配置模式修改为高级后手动修改存储配置参数，详见说明文档")
             }
 
-            GM_setValue(host + ".T0", T0);
-            GM_setValue(host + ".N0", N0);
-            GM_setValue(host + ".B0", B0);
-            GM_setValue(host + ".L", L);
+            setStoredParam("T0", T0);
+            setStoredParam("N0", N0);
+            setStoredParam("B0", B0);
+            setStoredParam("L", L);
 
         }
 
@@ -551,17 +655,21 @@ function run() {
      * @param i_N 做种人数人数所在列
      */
     function makeA($this, i_T, i_S, i_N) {
-        var time = $this.children('td:eq(' + i_T + ')').find("span").attr("title");
+        let $cells = $this.children('td,th')
+        var time = $cells.eq(i_T).find("span").attr("title");
         // 适配m-team的发生时间
         if (time == undefined || time == "") {
-            time = $this.children('td:eq(' + i_T + ')').find("span").text();
+            time = $cells.eq(i_T).find("span").text();
         }
         // 适配tjupt的发生时间
         if (time == undefined || time == "") {
-            time = $this.children('td:eq(' + i_T + ')').html().replace("<br>", " ").trim();
+            time = ($cells.eq(i_T).html() || '').replace("<br>", " ").trim();
+        }
+        if (time == undefined || time == "") {
+            time = $cells.eq(i_T).text().trim();
         }
         var T = (new Date().getTime() - new Date(time).getTime()) / 1e3 / 86400 / 7;
-        var size = $this.children('td:eq(' + i_S + ')').text().trim();
+        var size = $cells.eq(i_S).text().trim();
         var size_tp = 1;
         var S = size.replace(/[KMGT]i?B/, function (tp) {
             if (tp == "KB" || tp == "KiB") {
@@ -577,9 +685,12 @@ function run() {
         });
         S = parseFloat(S) * size_tp;
         //var number = $this.children('td:eq(' + i_N + ')').text().trim();
-        var number = $this.children('td:eq(' + i_N + ')').text().trim().replace(/,/g, ''); // 获取人数，删除多余符号
+        var number = $cells.eq(i_N).text().trim().replace(/,/g, ''); // 获取人数，删除多余符号
         //console.log(number);
         var N = parseInt(number);
+        if (!Number.isFinite(T) || !Number.isFinite(S) || !Number.isFinite(N)) {
+            return '<span title="无法解析发布时间、体积或做种人数">--</span>';
+        }
         var A = calcA(T, S, N).toFixed(2);
         var ave = (A / S).toFixed(2);
 
@@ -598,27 +709,32 @@ function run() {
 
     function addDataColGeneral() {
         var i_T, i_S, i_N
-        $(seedTableSelector).each(function (row) {
+        let rows = getGeneralSeedRows($)
+        if (!rows.length) {
+            return
+        }
+        let addFlag = false
+        rows.each(function (row) {
             var $this = $(this);
             if (row == 0) {
-                $this.children('td').each(function (col) {
-
-                    if ($(this).find('img.time').length) {
-                        i_T = col
-                    } else if ($(this).find('img.size').length) {
-                        i_S = col
-                    } else if ($(this).find('img.seeders').length) {
-                        i_N = col
-                    }
-                })
-                if (!i_T || !i_S || !i_N) {
+                addFlag = $this.text().indexOf('A@A/GB') != -1
+                let columns = detectTorrentColumns($this)
+                i_T = columns.time
+                i_S = columns.size
+                i_N = columns.seeders
+                if (i_T == null || i_S == null || i_N == null) {
                     alert('未能找到数据列')
                     return
                 }
-                $this.children("td:last").before("<td class=\"colhead\" title=\"A值@每GB的A值\">A@A/GB</td>");
+                if (!addFlag) {
+                    $this.children("td,th").last().before("<td class=\"colhead\" title=\"A值@每GB的A值\">A@A/GB</td>");
+                }
             } else {
+                if (i_T == null || i_S == null || i_N == null || addFlag) {
+                    return
+                }
                 var textA = makeA($this, i_T, i_S, i_N)
-                $this.children("td:last").before("<td class=\"rowfollow\">" + textA + "</td>");
+                $this.children("td,th").last().before("<td class=\"rowfollow\">" + textA + "</td>");
             }
         })
     }
@@ -667,7 +783,7 @@ function MTteamWaitPageLoadAndRun() {
     let T0Found = false
     let seedTableFound = false
     // 页面局部刷新后重新判断 isMybonusPage
-    isMybonusPage = window.location.toString().indexOf("mybonus") != -1
+    isMybonusPage = isBonusParamPage()
     let itv = setInterval(() => {
 
         if (isMybonusPage) {
@@ -701,10 +817,11 @@ function MTteamWaitPageLoadAndRun() {
     }, 100)
 }
 
-let host = window.location.host.match(/\b[^\.]+\.[^\.]+$/)[0]
+let host = getSiteKey()
+let legacyHost = getLegacySiteKey()
 let isMTeam = window.location.toString().indexOf("m-team") != -1
 let seedTableSelector = isMTeam ? 'div.mt-4>table>tbody>tr' : '.torrents:last-of-type>tbody>tr'
-let isMybonusPage = window.location.toString().indexOf("mybonus") != -1
+let isMybonusPage = isBonusParamPage()
 if (window.location.toString().indexOf("tjupt.org") != -1) {
     isMybonusPage = window.location.toString().indexOf("bonus.php") != -1
 }


### PR DESCRIPTION
## 变更内容

- 增强 M-Team `/mybonus` 页面参数提取，兼容新版文本结构。
- 增加 M-Team 基本奖励、做种奖励规则、当前活动做种数的容错解析。
- 根据 PT监护室中标记为“健康”的站点扩展 `@match` 匹配范围。
- 更新 README，补充支持范围说明和当前 fork 的反馈链接。

## 说明

本次扩展 `@match` 只表示脚本会在这些站点的 `torrents*` 页面注入，不代表所有站点都已经完成表格结构适配。

普通站点仍主要依赖 NexusPHP 类种子列表结构；如果站点使用非标准表格、前端重构页面，仍可能需要单独适配。

## 验证

- `node --check UserScript.js`