### PR TITLE
扩展站点匹配并改进魔力计算兼容性

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@
 
 ![](https://s2.loli.net/2022/02/04/kLu13N2l87zYTBa.png)
 
+### 支持范围与适配说明
+
+当前脚本已将 [PT监护室](https://savept.icu/) 中标记为“健康”的 140 个 PT 站点加入匹配规则，并同时覆盖主域名和子域名的 `torrents*` 页面。
+
+需要注意：加入匹配规则只代表脚本会在这些站点页面注入，不代表每个站点都已经完成表格结构适配。普通站点仍主要按 NexusPHP 类种子列表解析；如果站点使用了非标准表格、前端重构页面、不同的时间/体积/做种人数列结构，可能需要单独适配。
+
+`qingwapt.com`、`audiences.me`、`hdarea.club`、`hhanclub.net`、`monikadesign.uk` 已被排除，不启用脚本功能。
+
+如果某个站点的 `/mybonus.php` 页面无法解析出公式参数，脚本会把该站记录为不兼容站点，后续默认不再启用功能。
+
+M-Team 已做单独适配，覆盖：
+
+- `kp.m-team.cc`
+- `zp.m-team.io`
+
+M-Team 的 `/mybonus` 页面参数提取已支持新版文本结构，例如 `T0為參數。T0 = 4`、`N0 = 7`、`B0 = 50`、`L = 300`。
+
 ### 使用
 
 脚本安装：https://greasyfork.org/en/scripts/439369-pt站点魔力计算器
@@ -27,11 +44,11 @@
 
 ### 参与开发
 
-https://github.com/neoblackxt/PTMyBonusCalc
+https://github.com/huoyart/PTMyBonusCalc
 
 ### 问题反馈
 
-https://github.com/neoblackxt/PTMyBonusCalc/issues
+https://github.com/huoyart/PTMyBonusCalc/issues
 
 请将不支持的站点的种子列表和魔力值网页源代码粘贴在issue中，**注意把你的网站ID信息以及其他敏感信息删除，但不要破环网页结构** 不知道怎么删除请不要发出来（Ctrl + U 查看网页源代码，Ctrl + S 保存文件）。
 

--- a/UserScript.js
+++ b/UserScript.js
@@ -1,41 +1,300 @@
 // ==UserScript==
 // @name         PT站点魔力计算器
 // @namespace    https://github.com/neoblackxt/PTMyBonusCalc
-// @version      2.1.0
+// @version      2.3.4
 // @description  在使用NexusPHP架构的PT站点显示每个种子的A值和每GB的A值。
 // @author       neoblackxt, LaneLau
 // @require      https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js
 // @require      https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js
-// @match        *://*.beitai.pt/torrents*
-// @match        *://*.pttime.org/torrents*
-// @match        *://*.ptsbao.club/torrents*
-// @match        *://*.pthome.net/torrents*
 // @match        *://kp.m-team.cc/*
 // @match        *://zp.m-team.io/*
-// @match        *://*.hddolby.com/torrents*
-// @match        *://*.leaguehd.com/torrents*
-// @match        *://*.hdhome.org/torrents*
-// @match        *://*.hdsky.me/torrents*
-// @match        *://*.ourbits.club/torrents*
-// @match        *://*.u2.dmhy.org/torrents*
-// @match        *://*.hdzone.me/torrents*
-// @match        *://*.hdatmos.club/torrents*
-// @match        *://*.pt.soulvoice.club/torrents*
-// @match        *://*.pt.soulvoice.club/live*
-// @match        *://*.discfan.net/torrents*
-// @match        *://*.hdtime.org/torrents*
-// @match        *://*.nicept.net/torrents*
-// @match        *://*.pterclub.com/torrents*
-// @match        *://*.hdarea.co/torrents*
-// @match        *://*.hdfans.org/torrents*
-// @match        *://pt.btschool.club/torrents*
+// @match        *://13city.org/torrents*
+// @match        *://*.13city.org/torrents*
+// @match        *://1ptba.com/torrents*
 // @match        *://*.1ptba.com/torrents*
-// @match        *://www.oshen.win/torrents*
-// @match        *://*.rousi.zip/torrents*
+// @match        *://52movie.top/torrents*
+// @match        *://*.52movie.top/torrents*
+// @match        *://52pt.site/torrents*
+// @match        *://*.52pt.site/torrents*
+// @match        *://aither.cc/torrents*
+// @match        *://*.aither.cc/torrents*
+// @match        *://alpharatio.cc/torrents*
+// @match        *://*.alpharatio.cc/torrents*
+// @match        *://animez.to/torrents*
+// @match        *://*.animez.to/torrents*
+// @match        *://anthelion.me/torrents*
+// @match        *://*.anthelion.me/torrents*
+// @match        *://azusa.wiki/torrents*
+// @match        *://*.azusa.wiki/torrents*
+// @match        *://beyond-hd.me/torrents*
+// @match        *://*.beyond-hd.me/torrents*
+// @match        *://bilibili.download/torrents*
+// @match        *://*.bilibili.download/torrents*
+// @match        *://bitporn.eu/torrents*
+// @match        *://*.bitporn.eu/torrents*
+// @match        *://brokenstones.is/torrents*
+// @match        *://*.brokenstones.is/torrents*
+// @match        *://cangbao.ge/torrents*
+// @match        *://*.cangbao.ge/torrents*
+// @match        *://carpt.net/torrents*
+// @match        *://*.carpt.net/torrents*
+// @match        *://clearjav.com/torrents*
+// @match        *://*.clearjav.com/torrents*
+// @match        *://crabpt.vip/torrents*
+// @match        *://*.crabpt.vip/torrents*
+// @match        *://cspt.top/torrents*
+// @match        *://*.cspt.top/torrents*
+// @match        *://cyanbug.net/torrents*
+// @match        *://*.cyanbug.net/torrents*
+// @match        *://dicmusic.com/torrents*
+// @match        *://*.dicmusic.com/torrents*
+// @match        *://discfan.net/torrents*
+// @match        *://*.discfan.net/torrents*
+// @match        *://dragonhd.xyz/torrents*
+// @match        *://*.dragonhd.xyz/torrents*
+// @match        *://dstudio.me/torrents*
+// @match        *://*.dstudio.me/torrents*
+// @match        *://dubhe.site/torrents*
+// @match        *://*.dubhe.site/torrents*
+// @match        *://duckboobee.org/torrents*
+// @match        *://*.duckboobee.org/torrents*
+// @match        *://empornium.sx/torrents*
+// @match        *://*.empornium.sx/torrents*
+// @match        *://et8.org/torrents*
+// @match        *://*.et8.org/torrents*
+// @match        *://exoticaz.to/torrents*
+// @match        *://*.exoticaz.to/torrents*
+// @match        *://fappaizuri.me/torrents*
+// @match        *://*.fappaizuri.me/torrents*
+// @match        *://fearnopeer.com/torrents*
+// @match        *://*.fearnopeer.com/torrents*
+// @match        *://filelist.io/torrents*
+// @match        *://*.filelist.io/torrents*
+// @match        *://gamegamept.com/torrents*
+// @match        *://*.gamegamept.com/torrents*
+// @match        *://generation-free.org/torrents*
+// @match        *://*.generation-free.org/torrents*
+// @match        *://greatposterwall.com/torrents*
+// @match        *://*.greatposterwall.com/torrents*
+// @match        *://haidan.cc/torrents*
+// @match        *://*.haidan.cc/torrents*
+// @match        *://happyfappy.net/torrents*
+// @match        *://*.happyfappy.net/torrents*
+// @match        *://hawke.uno/torrents*
+// @match        *://*.hawke.uno/torrents*
+// @match        *://hdbao.cc/torrents*
+// @match        *://*.hdbao.cc/torrents*
+// @match        *://hdcity.city/torrents*
+// @match        *://*.hdcity.city/torrents*
+// @match        *://hddolby.com/torrents*
+// @match        *://*.hddolby.com/torrents*
+// @match        *://hdfans.org/torrents*
+// @match        *://*.hdfans.org/torrents*
+// @match        *://hdhome.org/torrents*
+// @match        *://*.hdhome.org/torrents*
+// @match        *://hdkyl.in/torrents*
+// @match        *://*.hdkyl.in/torrents*
+// @match        *://hdsky.me/torrents*
+// @match        *://*.hdsky.me/torrents*
+// @match        *://hdtime.org/torrents*
+// @match        *://*.hdtime.org/torrents*
+// @match        *://hd-torrents.org/torrents*
+// @match        *://*.hd-torrents.org/torrents*
+// @match        *://hdvideo.top/torrents*
+// @match        *://*.hdvideo.top/torrents*
+// @match        *://hitpt.com/torrents*
+// @match        *://*.hitpt.com/torrents*
+// @match        *://htpt.cc/torrents*
+// @match        *://*.htpt.cc/torrents*
+// @match        *://hxpt.org/torrents*
+// @match        *://*.hxpt.org/torrents*
+// @match        *://iptorrents.com/torrents*
+// @match        *://*.iptorrents.com/torrents*
+// @match        *://jpopsuki.eu/torrents*
+// @match        *://*.jpopsuki.eu/torrents*
+// @match        *://kamept.com/torrents*
+// @match        *://*.kamept.com/torrents*
+// @match        *://kp.m-team.cc/torrents*
+// @match        *://*.kp.m-team.cc/torrents*
+// @match        *://kufei.org/torrents*
 // @match        *://*.kufei.org/torrents*
+// @match        *://lemonhd.net/torrents*
+// @match        *://*.lemonhd.net/torrents*
+// @match        *://longpt.org/torrents*
+// @match        *://*.longpt.org/torrents*
+// @match        *://lst.gg/torrents*
+// @match        *://*.lst.gg/torrents*
+// @match        *://milkie.cc/torrents*
+// @match        *://*.milkie.cc/torrents*
+// @match        *://momentpt.top/torrents*
+// @match        *://*.momentpt.top/torrents*
+// @match        *://morethantv.me/torrents*
+// @match        *://*.morethantv.me/torrents*
+// @match        *://mua.xloli.cc/torrents*
+// @match        *://*.mua.xloli.cc/torrents*
+// @match        *://musopia.vip/torrents*
+// @match        *://*.musopia.vip/torrents*
+// @match        *://myanonamouse.net/torrents*
+// @match        *://*.myanonamouse.net/torrents*
+// @match        *://nanyangpt.com/torrents*
+// @match        *://*.nanyangpt.com/torrents*
+// @match        *://nebulance.io/torrents*
+// @match        *://*.nebulance.io/torrents*
+// @match        *://nicept.net/torrents*
+// @match        *://*.nicept.net/torrents*
+// @match        *://njtupt.top/torrents*
+// @match        *://*.njtupt.top/torrents*
+// @match        *://okpt.net/torrents*
+// @match        *://*.okpt.net/torrents*
+// @match        *://open.cd/torrents*
+// @match        *://*.open.cd/torrents*
+// @match        *://orpheus.network/torrents*
+// @match        *://*.orpheus.network/torrents*
+// @match        *://our.kelu.one/torrents*
+// @match        *://*.our.kelu.one/torrents*
+// @match        *://ourbits.club/torrents*
+// @match        *://*.ourbits.club/torrents*
+// @match        *://p.t-baozi.cc/torrents*
+// @match        *://*.p.t-baozi.cc/torrents*
+// @match        *://pandapt.net/torrents*
+// @match        *://*.pandapt.net/torrents*
+// @match        *://piggo.me/torrents*
+// @match        *://*.piggo.me/torrents*
+// @match        *://playlet.cc/torrents*
+// @match        *://*.playlet.cc/torrents*
+// @match        *://pt.0ff.cc/torrents*
+// @match        *://*.pt.0ff.cc/torrents*
+// @match        *://pt.agsvpt.cn/torrents*
+// @match        *://*.pt.agsvpt.cn/torrents*
+// @match        *://agsvpt.com/torrents*
+// @match        *://*.agsvpt.com/torrents*
+// @match        *://pt.aling.de/torrents*
+// @match        *://*.pt.aling.de/torrents*
+// @match        *://pt.btschool.club/torrents*
+// @match        *://*.pt.btschool.club/torrents*
+// @match        *://pt.cdy.skin/torrents*
+// @match        *://*.pt.cdy.skin/torrents*
+// @match        *://pt.eastgame.org/torrents*
+// @match        *://*.pt.eastgame.org/torrents*
+// @match        *://pt.gtkpw.xyz/torrents*
+// @match        *://*.pt.gtkpw.xyz/torrents*
+// @match        *://pt.hdclone.top/torrents*
+// @match        *://*.pt.hdclone.top/torrents*
+// @match        *://pt.hdupt.com/torrents*
+// @match        *://*.pt.hdupt.com/torrents*
+// @match        *://pt.itzmx.com/torrents*
+// @match        *://*.pt.itzmx.com/torrents*
+// @match        *://pt.keepfrds.com/torrents*
+// @match        *://*.pt.keepfrds.com/torrents*
+// @match        *://pt.lajidui.top/torrents*
+// @match        *://*.pt.lajidui.top/torrents*
+// @match        *://pt.luckpt.de/torrents*
+// @match        *://*.pt.luckpt.de/torrents*
+// @match        *://pt.muxuege.org/torrents*
+// @match        *://*.pt.muxuege.org/torrents*
+// @match        *://pt.mypt.cc/torrents*
+// @match        *://*.pt.mypt.cc/torrents*
+// @match        *://pt.sjtu.edu.cn/torrents*
+// @match        *://*.pt.sjtu.edu.cn/torrents*
+// @match        *://pt.soulvoice.club/torrents*
+// @match        *://*.pt.soulvoice.club/torrents*
+// @match        *://pt.tey.cc/torrents*
+// @match        *://*.pt.tey.cc/torrents*
+// @match        *://pt.tu88.men/torrents*
+// @match        *://*.pt.tu88.men/torrents*
+// @match        *://pt.xingyungept.org/torrents*
+// @match        *://*.pt.xingyungept.org/torrents*
+// @match        *://pt.ying.us.kg/torrents*
+// @match        *://*.pt.ying.us.kg/torrents*
+// @match        *://ptcafe.club/torrents*
+// @match        *://*.ptcafe.club/torrents*
+// @match        *://ptchdbits.co/torrents*
+// @match        *://*.ptchdbits.co/torrents*
+// @match        *://pterclub.net/torrents*
+// @match        *://*.pterclub.net/torrents*
+// @match        *://ptfans.cc/torrents*
+// @match        *://*.ptfans.cc/torrents*
+// @match        *://pthome.net/torrents*
+// @match        *://*.pthome.net/torrents*
+// @match        *://ptlao.top/torrents*
+// @match        *://*.ptlao.top/torrents*
+// @match        *://ptlgs.org/torrents*
+// @match        *://*.ptlgs.org/torrents*
+// @match        *://ptsbao.club/torrents*
+// @match        *://*.ptsbao.club/torrents*
+// @match        *://ptskit.org/torrents*
+// @match        *://*.ptskit.org/torrents*
+// @match        *://pttime.org/torrents*
+// @match        *://*.pttime.org/torrents*
+// @match        *://ptzone.xyz/torrents*
+// @match        *://*.ptzone.xyz/torrents*
+// @match        *://raingfh.top/torrents*
+// @match        *://*.raingfh.top/torrents*
+// @match        *://rousi.pro/torrents*
+// @match        *://*.rousi.pro/torrents*
+// @match        *://sbpt.link/torrents*
+// @match        *://*.sbpt.link/torrents*
+// @match        *://sewerpt.com/torrents*
+// @match        *://*.sewerpt.com/torrents*
+// @match        *://si-qi.xyz/torrents*
+// @match        *://*.si-qi.xyz/torrents*
+// @match        *://sportscult.org/torrents*
+// @match        *://*.sportscult.org/torrents*
+// @match        *://springsunday.net/torrents*
+// @match        *://*.springsunday.net/torrents*
+// @match        *://star-space.net/torrents*
+// @match        *://*.star-space.net/torrents*
+// @match        *://sunnypt.top/torrents*
+// @match        *://*.sunnypt.top/torrents*
+// @match        *://tangpt.top/torrents*
+// @match        *://*.tangpt.top/torrents*
+// @match        *://tjupt.org/torrents*
 // @match        *://*.tjupt.org/torrents*
+// @match        *://tokyo-manga.top/torrents*
+// @match        *://*.tokyo-manga.top/torrents*
+// @match        *://torrentleech.cc/torrents*
+// @match        *://*.torrentleech.cc/torrents*
+// @match        *://totheglory.im/torrents*
+// @match        *://*.totheglory.im/torrents*
+// @match        *://tracker.novahd.top/torrents*
+// @match        *://*.tracker.novahd.top/torrents*
+// @match        *://u2.dmhy.org/torrents*
+// @match        *://*.u2.dmhy.org/torrents*
+// @match        *://ubits.club/torrents*
+// @match        *://*.ubits.club/torrents*
+// @match        *://ultrahd.net/torrents*
+// @match        *://*.ultrahd.net/torrents*
+// @match        *://web.yemapt.org/torrents*
+// @match        *://*.web.yemapt.org/torrents*
+// @match        *://wintersakura.net/torrents*
+// @match        *://*.wintersakura.net/torrents*
+// @match        *://xingtan.one/torrents*
+// @match        *://*.xingtan.one/torrents*
+// @match        *://xingwan.cc/torrents*
+// @match        *://*.xingwan.cc/torrents*
+// @match        *://yhpp.cc/torrents*
+// @match        *://*.yhpp.cc/torrents*
+// @match        *://zhuque.in/torrents*
+// @match        *://*.zhuque.in/torrents*
+// @match        *://zmpt.cc/torrents*
+// @match        *://*.zmpt.cc/torrents*
+// @match        *://zrpt.cc/torrents*
+// @match        *://*.zrpt.cc/torrents*
+// @match        *://pt.soulvoice.club/live*
+// @match        *://*.pt.soulvoice.club/live*
+// @match        *://tjupt.org/bonus*
 // @match        *://*.tjupt.org/bonus*
 // @match        *://*/mybonus*
+// @exclude      *://qingwapt.com/*
+// @exclude      *://*.qingwapt.com/*
+// @exclude      *://audiences.me/*
+// @exclude      *://*.audiences.me/*
+// @exclude      *://hdarea.club/*
+// @exclude      *://*.hdarea.club/*
+// @exclude      *://hhanclub.net/*
+// @exclude      *://*.hhanclub.net/*
+// @exclude      *://monikadesign.uk/*
+// @exclude      *://*.monikadesign.uk/*
 // @license      GPL License
 // @grant        GM_setValue
 // @grant        GM_getValue
@@ -51,47 +310,371 @@ const colorsOfAVE = [
     {min: 2, max: Infinity, color: '#ff0000', fontWeight: 900} // 红色
 ]
 
+function extractBonusParam(text, name, allowLoose = true) {
+    if (!text) {
+        return undefined
+    }
+    let normalized = text.replace(/\s+/g, ' ')
+    let escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    let strictReg = new RegExp('(?:^|[^A-Za-z0-9])' + escapedName + '(?![A-Za-z0-9])\\s*(?:=|:|：)\\s*(\\d+(?:\\.\\d+)?)', 'i')
+    let strictMatch = normalized.match(strictReg)
+    if (strictMatch) {
+        return parseFloat(strictMatch[1])
+    }
+
+    if (!allowLoose || normalized.length > 120) {
+        return undefined
+    }
+    let looseReg = new RegExp('(?:^|[^A-Za-z0-9])' + escapedName + '(?![A-Za-z0-9])\\s+(\\d+(?:\\.\\d+)?)', 'i')
+    let looseMatch = normalized.match(looseReg)
+    return looseMatch ? parseFloat(looseMatch[1]) : undefined
+}
+
+function getBonusParamFromPage(name) {
+    let nodes = document.querySelectorAll('li, div, p, span, td, th, tr')
+    for (let node of nodes) {
+        let value = extractBonusParam(node.innerText, name)
+        if (Number.isFinite(value)) {
+            return value
+        }
+    }
+    return extractBonusParam(document.body ? document.body.innerText : '', name, false)
+}
+
+function getBonusParamsFromPage() {
+    return {
+        T0: getBonusParamFromPage('T0'),
+        N0: getBonusParamFromPage('N0'),
+        B0: getBonusParamFromPage('B0'),
+        L: getBonusParamFromPage('L')
+    }
+}
+
+function getSiteKey() {
+    return (window.location.hostname || window.location.host || '').replace(/^www\./, '')
+}
+
+function getLegacySiteKey() {
+    let match = (window.location.host || '').match(/\b[^\.]+\.[^\.]+$/)
+    return match ? match[0] : getSiteKey()
+}
+
+function isIgnoredSite() {
+    let hostname = getSiteKey()
+    let ignoredHosts = ['qingwapt.com', 'audiences.me', 'hdarea.club', 'hhanclub.net', 'monikadesign.uk']
+    return ignoredHosts.some(site => hostname === site || hostname.endsWith('.' + site))
+}
+
+function getSiteDisabledKey() {
+    return host + ".disabledByInvalidBonusPage"
+}
+
+function isSiteDisabledByInvalidBonusPage() {
+    let value = GM_getValue(getSiteDisabledKey())
+    if (!value && legacyHost && legacyHost !== host) {
+        value = GM_getValue(legacyHost + ".disabledByInvalidBonusPage")
+    }
+    return value === true
+}
+
+function markSiteDisabledByInvalidBonusPage() {
+    GM_setValue(getSiteDisabledKey(), true)
+}
+
+function clearSiteDisabledByInvalidBonusPage() {
+    GM_setValue(getSiteDisabledKey(), false)
+}
+
+function getStoredParam(name) {
+    let value = GM_getValue(host + "." + name)
+    if (!value && legacyHost && legacyHost !== host) {
+        value = GM_getValue(legacyHost + "." + name)
+    }
+    return value
+}
+
+function setStoredParam(name, value) {
+    GM_setValue(host + "." + name, value)
+}
+
+function isBonusParamPage() {
+    return /\/(?:mybonus|bonus)(?:\.php)?(?:[?#/]|$)/i.test(window.location.pathname)
+}
+
+function isMybonusParamPage() {
+    return /\/mybonus(?:\.php)?(?:[?#/]|$)/i.test(window.location.pathname)
+}
+
+function parseFirstNumber(text) {
+    let match = (text || '').replace(/,/g, '').match(/\d+(?:\.\d+)?/)
+    return match ? parseFloat(match[0]) : undefined
+}
+
+function getMTeamBasicBonus($) {
+    let basicBonus;
+    $("td:contains('基本獎勵')").each(function () {
+        if (Number.isFinite(basicBonus)) {
+            return false
+        }
+        let oldLayoutValue = parseFirstNumber($(this).next('td').next('td').text())
+        if (Number.isFinite(oldLayoutValue)) {
+            basicBonus = oldLayoutValue
+            return false
+        }
+        let values = $(this).nextAll('td').map(function () {
+            return parseFirstNumber($(this).text())
+        }).get().filter(Number.isFinite)
+        if (values.length) {
+            basicBonus = values[0]
+        }
+    });
+    return basicBonus
+}
+
+function getMTeamSeedingBonusRule() {
+    let text = document.body ? document.body.innerText.replace(/\s+/g, ' ') : ''
+    let match = text.match(/(\d+(?:\.\d+)?)\s*個魔力值\s*\*\s*你的做種數.*?最多計\s*(\d+)\s*個/)
+    return match ? {
+        perSeed: parseFloat(match[1]),
+        limit: parseInt(match[2])
+    } : undefined
+}
+
+function getMTeamCurrentSeeding() {
+    let text = document.body ? document.body.innerText.replace(/\s+/g, ' ') : ''
+    let match = text.match(/當前活動\s*[:：]\s*(\d+)/)
+    return match ? parseInt(match[1]) : undefined
+}
+
+function getCellSignature($cell) {
+    let imageMeta = $cell.find('img').map(function () {
+        return [
+            this.className,
+            this.alt,
+            this.title,
+            this.src
+        ].join(' ')
+    }).get().join(' ')
+    return [
+        $cell.text(),
+        $cell.attr('title'),
+        imageMeta,
+        $cell.html()
+    ].join(' ').toLowerCase()
+}
+
+function detectTorrentColumns($headerRow) {
+    let columns = {time: null, size: null, seeders: null}
+    $headerRow.children('td,th').each(function (col) {
+        let $cell = jQuery(this)
+        let sig = getCellSignature($cell)
+        if (columns.time == null && (
+            $cell.find('img.time').length ||
+            /\btime\b|added|date|publish|發布|发布|時間|时间/.test(sig)
+        )) {
+            columns.time = col
+        } else if (columns.size == null && (
+            $cell.find('img.size').length ||
+            /\bsize\b|大小|體積|体积/.test(sig)
+        )) {
+            columns.size = col
+        } else if (columns.seeders == null && (
+            $cell.find('img.seeders').length ||
+            /seeders?|做種|做种|做種者|做种者|種子數|种子数/.test(sig)
+        )) {
+            columns.seeders = col
+        }
+    })
+    return columns
+}
+
+function getGeneralSeedRows($) {
+    let selectors = [
+        '.torrents:last-of-type>tbody>tr',
+        'table.torrents:last-of-type>tbody>tr',
+        'table#torrent_table>tbody>tr',
+        'table[class*="torrent"]:last-of-type>tbody>tr'
+    ]
+    for (let selector of selectors) {
+        let rows = $(selector)
+        if (rows.length > 1) {
+            return rows
+        }
+    }
+
+    let bestRows = $()
+    $('table').each(function () {
+        let rows = $(this).find('tbody>tr')
+        if (rows.length <= 1) {
+            rows = $(this).find('tr')
+        }
+        if (rows.length <= 1) {
+            return
+        }
+        let columns = detectTorrentColumns(rows.first())
+        if (columns.time != null && columns.size != null && columns.seeders != null) {
+            bestRows = rows
+        }
+    })
+    return bestRows
+}
+
+const formulaProfiles = {
+    default: {
+        name: 'NexusPHP',
+        requiredParams: ['T0', 'N0', 'B0', 'L'],
+        supportsBonusChart: true,
+        columnTitle: 'A@A/GB',
+        columnTip: 'A值@每GB的A值',
+        calcA: function (T, S, N, rowText, params) {
+            var c1 = 1 - Math.pow(10, -(T / params.T0));
+            N = N ? N : 1;
+            var c2 = 1 + Math.pow(2, .5) * Math.pow(10, -(N - 1) / (params.N0 - 1));
+            return c1 * S * c2;
+        },
+        calcB: function (A, params) {
+            return params.B0 * (2 / Math.PI) * Math.atan(A / params.L)
+        }
+    },
+    audiences: {
+        name: 'Audiences',
+        requiredParams: ['T0', 'N0', 'L'],
+        supportsBonusChart: false,
+        columnTitle: 'A@A/GB',
+        columnTip: '含官组/普通权重的A值@每GB的A值',
+        calcA: function (T, S, N, rowText, params) {
+            N = N ? N : 1;
+            let adjustedSize = S;
+            if (rowText.indexOf('零魔') !== -1) {
+                if (N >= 10) {
+                    return 0;
+                }
+                adjustedSize = S / 5;
+            }
+            let weight = /官组|官組|官方/.test(rowText) ? 1.5 : 0.5;
+            let c1 = 1 - Math.pow(10, -(T / params.T0));
+            let c2 = 1 + Math.pow(2, .5) * Math.pow(10, -(N - 1) / (params.N0 - 1));
+            return c1 * adjustedSize * c2 * weight;
+        }
+    },
+    hdarea: {
+        name: 'HDArea v2',
+        requiredParams: [],
+        supportsBonusChart: false,
+        columnTitle: 'Score@Score/GB',
+        columnTip: 'HDArea新版算法单种预估分@每GB预估分，未扣除全局上限',
+        calcA: function (T, S, N) {
+            N = N ? N : 1;
+            let countScore = S > 5 ? 1 : 0;
+            let scarcityScore = S * (1 + Math.max(T, 0) * 0.02) * (1 + 1 / N) * 0.05;
+            return countScore + scarcityScore;
+        }
+    },
+    hhanclub: {
+        name: 'HHANClub',
+        requiredParams: [],
+        supportsBonusChart: false,
+        disableTorrentCalc: true,
+        unsupportedMessage: 'HHANClub魔力页未提供完整基础公式参数，暂不计算单种A值，避免显示错误结果。'
+    }
+}
+
+function getFormulaProfile() {
+    if (host === 'audiences.me') {
+        return formulaProfiles.audiences
+    }
+    if (host === 'hdarea.club') {
+        return formulaProfiles.hdarea
+    }
+    if (host === 'hhanclub.net') {
+        return formulaProfiles.hhanclub
+    }
+    return formulaProfiles.default
+}
+
+function areParamsReady(profile, params) {
+    return profile.requiredParams.every(name => Number.isFinite(params[name]) && params[name] !== 0)
+}
+
+function getCurrentParams(T0, N0, B0, L) {
+    return {T0: Number(T0), N0: Number(N0), B0: Number(B0), L: Number(L)}
+}
+
 function run() {
     var $ = jQuery;
+    let formulaProfile = getFormulaProfile();
+    if (formulaProfile.disableTorrentCalc) {
+        if (!isMybonusPage && !GM_getValue(host + ".unsupportedFormulaNoticeShown")) {
+            GM_setValue(host + ".unsupportedFormulaNoticeShown", true)
+            alert(formulaProfile.unsupportedMessage)
+        }
+        return
+    }
 
 
-    let argsReady = true;
-    let T0 = GM_getValue(host + ".T0");
-    let N0 = GM_getValue(host + ".N0");
-    let B0 = GM_getValue(host + ".B0");
-    let L = GM_getValue(host + ".L");
-    if (!(T0 && N0 && B0 && L)) {
-        argsReady = false
+    let T0 = getStoredParam("T0");
+    let N0 = getStoredParam("N0");
+    let B0 = getStoredParam("B0");
+    let L = getStoredParam("L");
+    let argsReady = areParamsReady(formulaProfile, getCurrentParams(T0, N0, B0, L));
+    let argsReadyBeforePageParse = argsReady;
+    if (!argsReady) {
         if (!isMybonusPage) {
             alert("未找到魔力值参数,请打开魔力值系统说明获取（/mybonus）");
         }
     }
     if (isMybonusPage) {
 
+        let pageParamsReady = false;
         try {
-            T0 = parseInt($("li:has(b:contains('T0'))")[1].innerText.split(" = ")[1]);
-            N0 = parseInt($("li:has(b:contains('N0'))")[1].innerText.split(" = ")[1]);
-            B0 = parseInt($("li:has(b:contains('B0'))")[1].innerText.split(" = ")[1]);
-            L = parseInt($("li:has(b:contains('L'))")[1].innerText.split(" = ")[1]);
+            let params = getBonusParamsFromPage();
+            pageParamsReady = areParamsReady(formulaProfile, params);
+            if (Number.isFinite(params.T0)) {
+                T0 = params.T0;
+            }
+            if (Number.isFinite(params.N0)) {
+                N0 = params.N0;
+            }
+            if (Number.isFinite(params.B0)) {
+                B0 = params.B0;
+            }
+            if (Number.isFinite(params.L)) {
+                L = params.L;
+            }
+            argsReady = areParamsReady(formulaProfile, getCurrentParams(T0, N0, B0, L));
+            if (!pageParamsReady) {
+                throw new Error("未在页面文本中找到当前站点公式所需参数: " + formulaProfile.requiredParams.join('/'));
+            }
             console.log('数据提取成功:', T0, N0, B0, L);
         } catch (error) {
             console.error('数据提取过程中出现错误:', error);
         }
 
-        if (!argsReady) {
-            if (T0 && N0 && B0 && L) {
-                argsReady = true
-                alert("魔力值参数已更新")
-            } else {
-                T0 = N0 = B0 = L = 0;
-                alert("魔力值参数获取失败,请将Tampermonkey的配置模式修改为高级后手动修改存储配置参数，详见说明文档")
+        if (!pageParamsReady && isMybonusParamPage() && !isMTeam && formulaProfile.requiredParams.length) {
+            markSiteDisabledByInvalidBonusPage();
+            console.warn('mybonus 页面无法解析公式参数，已标记该站不启用 PT 魔力计算器。');
+            return
+        }
+
+        if (argsReady) {
+            clearSiteDisabledByInvalidBonusPage();
+            if (Number.isFinite(Number(T0))) {
+                setStoredParam("T0", T0);
             }
-
-            GM_setValue(host + ".T0", T0);
-            GM_setValue(host + ".N0", N0);
-            GM_setValue(host + ".B0", B0);
-            GM_setValue(host + ".L", L);
-
+            if (Number.isFinite(Number(N0))) {
+                setStoredParam("N0", N0);
+            }
+            if (Number.isFinite(Number(B0))) {
+                setStoredParam("B0", B0);
+            }
+            if (Number.isFinite(Number(L))) {
+                setStoredParam("L", L);
+            }
+            if (!argsReadyBeforePageParse && formulaProfile.requiredParams.length) {
+                alert("魔力值参数已更新")
+            }
+        } else if (formulaProfile.requiredParams.length) {
+            alert("魔力值参数获取失败,请将Tampermonkey的配置模式修改为高级后手动修改存储配置参数，详见说明文档")
         }
 
         if (!argsReady) {
@@ -100,7 +683,7 @@ function run() {
         }
 
         function calcB(A) {
-            return B0 * (2 / Math.PI) * Math.atan(A / L)
+            return formulaProfile.calcB(A, getCurrentParams(T0, N0, B0, L))
         }
 
         function calcAbyB(B) {
@@ -108,19 +691,22 @@ function run() {
             return Math.tan(B / B0 / (2 / Math.PI)) * L
         }
 
+        if (!formulaProfile.supportsBonusChart) {
+            return
+        }
+
         let A = isMTeam ? 0 : parseFloat($("div:contains(' (A = ')")[0].innerText.split(" = ")[1]);
-        let B = isMTeam ? parseFloat($("td:contains('基本獎勵')+td+td")[0].innerText) : calcB(A);
+        let B = isMTeam ? getMTeamBasicBonus($) : calcB(A);
+        if (isMTeam && !Number.isFinite(B)) {
+            alert("未找到M-Team基本獎勵，无法绘制 B-A 图");
+            return
+        }
         // 剔除M-Team的基本奖励中做种数奖励
         if (isMTeam) {
-            let matches = $("h5:contains('做種每小時將得到如下的魔力值')").next().children().first().text()
-                .match(/(\d+(\.\d+)?)個魔力值.*最多計(\d+)個/);
-            let seedingBonusPerSeed = parseFloat(matches[1]);
-            let seedingBonusLimit = parseInt(matches[3]);
-            let currentSeedingNode = $("span:contains('當前活動')").parent().clone();
-            currentSeedingNode.find('img').replaceWith(function () {
-                return "img";
-            });
-            let currentSeeding = parseInt(currentSeedingNode.text().match(/(\d+)/)[1]);
+            let seedingBonusRule = getMTeamSeedingBonusRule();
+            let seedingBonusPerSeed = seedingBonusRule ? seedingBonusRule.perSeed : 0;
+            let seedingBonusLimit = seedingBonusRule ? seedingBonusRule.limit : 0;
+            let currentSeeding = getMTeamCurrentSeeding() || 0;
             B = B - (currentSeeding > seedingBonusLimit ?
                 seedingBonusPerSeed * seedingBonusLimit : seedingBonusPerSeed * currentSeeding);
         }
@@ -193,13 +779,7 @@ function run() {
 
 
     function calcA(T, S, N) {
-        var c1 = 1 - Math.pow(10, -(T / T0));
-        // 当断种时，显示续种后的实际值，因为当前状态值无意义
-        N = N ? N : 1;
-        // 当前状态值，加入做种后实际值会小于当前值
-        // TODO: 改为双行显示为当前值和实际值
-        var c2 = 1 + Math.pow(2, .5) * Math.pow(10, -(N - 1) / (N0 - 1));
-        return c1 * S * c2;
+        return formulaProfile.calcA(T, S, N, '', getCurrentParams(T0, N0, B0, L));
     }
 
     /**
@@ -210,17 +790,21 @@ function run() {
      * @param i_N 做种人数人数所在列
      */
     function makeA($this, i_T, i_S, i_N) {
-        var time = $this.children('td:eq(' + i_T + ')').find("span").attr("title");
+        let $cells = $this.children('td,th')
+        var time = $cells.eq(i_T).find("span").attr("title");
         // 适配m-team的发生时间
         if (time == undefined || time == "") {
-            time = $this.children('td:eq(' + i_T + ')').find("span").text();
+            time = $cells.eq(i_T).find("span").text();
         }
         // 适配tjupt的发生时间
         if (time == undefined || time == "") {
-            time = $this.children('td:eq(' + i_T + ')').html().replace("<br>", " ").trim();
+            time = ($cells.eq(i_T).html() || '').replace("<br>", " ").trim();
+        }
+        if (time == undefined || time == "") {
+            time = $cells.eq(i_T).text().trim();
         }
         var T = (new Date().getTime() - new Date(time).getTime()) / 1e3 / 86400 / 7;
-        var size = $this.children('td:eq(' + i_S + ')').text().trim();
+        var size = $cells.eq(i_S).text().trim();
         var size_tp = 1;
         var S = size.replace(/[KMGT]i?B/, function (tp) {
             if (tp == "KB" || tp == "KiB") {
@@ -236,10 +820,14 @@ function run() {
         });
         S = parseFloat(S) * size_tp;
         //var number = $this.children('td:eq(' + i_N + ')').text().trim();
-        var number = $this.children('td:eq(' + i_N + ')').text().trim().replace(/,/g, ''); // 获取人数，删除多余符号
+        var number = $cells.eq(i_N).text().trim().replace(/,/g, ''); // 获取人数，删除多余符号
         //console.log(number);
         var N = parseInt(number);
-        var A = calcA(T, S, N).toFixed(2);
+        if (!Number.isFinite(T) || !Number.isFinite(S) || !Number.isFinite(N)) {
+            return '<span title="无法解析发布时间、体积或做种人数">--</span>';
+        }
+        var rowText = $this.text();
+        var A = formulaProfile.calcA(T, S, N, rowText, getCurrentParams(T0, N0, B0, L)).toFixed(2);
         var ave = (A / S).toFixed(2);
 
         var textA = '<span>' + A + '@' + ave + '</span>';
@@ -257,27 +845,35 @@ function run() {
 
     function addDataColGeneral() {
         var i_T, i_S, i_N
-        $(seedTableSelector).each(function (row) {
+        let rows = getGeneralSeedRows($)
+        if (!rows.length) {
+            return
+        }
+        let addFlag = false
+        rows.each(function (row) {
             var $this = $(this);
             if (row == 0) {
-                $this.children('td').each(function (col) {
-
-                    if ($(this).find('img.time').length) {
-                        i_T = col
-                    } else if ($(this).find('img.size').length) {
-                        i_S = col
-                    } else if ($(this).find('img.seeders').length) {
-                        i_N = col
-                    }
-                })
-                if (!i_T || !i_S || !i_N) {
+                let headerText = $this.text()
+                addFlag = headerText.indexOf(formulaProfile.columnTitle) != -1
+                    || headerText.indexOf('A@A/GB') != -1
+                    || headerText.indexOf('Score@Score/GB') != -1
+                let columns = detectTorrentColumns($this)
+                i_T = columns.time
+                i_S = columns.size
+                i_N = columns.seeders
+                if (i_T == null || i_S == null || i_N == null) {
                     alert('未能找到数据列')
                     return
                 }
-                $this.children("td:last").before("<td class=\"colhead\" title=\"A值@每GB的A值\">A@A/GB</td>");
+                if (!addFlag) {
+                    $this.children("td,th").last().before("<td class=\"colhead\" title=\"" + formulaProfile.columnTip + "\">" + formulaProfile.columnTitle + "</td>");
+                }
             } else {
+                if (i_T == null || i_S == null || i_N == null || addFlag) {
+                    return
+                }
                 var textA = makeA($this, i_T, i_S, i_N)
-                $this.children("td:last").before("<td class=\"rowfollow\">" + textA + "</td>");
+                $this.children("td,th").last().before("<td class=\"rowfollow\">" + textA + "</td>");
             }
         })
     }
@@ -326,11 +922,11 @@ function MTteamWaitPageLoadAndRun() {
     let T0Found = false
     let seedTableFound = false
     // 页面局部刷新后重新判断 isMybonusPage
-    isMybonusPage = window.location.toString().indexOf("mybonus") != -1
+    isMybonusPage = isBonusParamPage()
     let itv = setInterval(() => {
 
         if (isMybonusPage) {
-            T0Found = $("li:has(b:contains('T0'))")[1]
+            T0Found = Number.isFinite(getBonusParamFromPage('T0'))
 
         }
         if (T0Found || seedTableFound || count >= 100) {
@@ -360,14 +956,17 @@ function MTteamWaitPageLoadAndRun() {
     }, 100)
 }
 
-let host = window.location.host.match(/\b[^\.]+\.[^\.]+$/)[0]
+let host = getSiteKey()
+let legacyHost = getLegacySiteKey()
 let isMTeam = window.location.toString().indexOf("m-team") != -1
 let seedTableSelector = isMTeam ? 'div.mt-4>table>tbody>tr' : '.torrents:last-of-type>tbody>tr'
-let isMybonusPage = window.location.toString().indexOf("mybonus") != -1
+let isMybonusPage = isBonusParamPage()
 if (window.location.toString().indexOf("tjupt.org") != -1) {
     isMybonusPage = window.location.toString().indexOf("bonus.php") != -1
 }
-if (isMTeam) {
+if (isIgnoredSite() || (isSiteDisabledByInvalidBonusPage() && !isMybonusPage)) {
+    // skip ignored sites and sites whose mybonus page is not parseable
+} else if (isMTeam) {
     if (isMybonusPage || window.location.toString().indexOf("browse") != -1) {
         MTteamWaitPageLoadAndRun()
     }
@@ -376,7 +975,12 @@ if (isMTeam) {
 }
 
 var currentUrl = window.location.href;
-if (window.onurlchange === null) {
+if (!isIgnoredSite() && !(isSiteDisabledByInvalidBonusPage() && !isMybonusPage) && window.onurlchange === null) {
     // M-Team 页面局部刷新时重新运行函数
-    window.addEventListener('urlchange', (info) => MTteamWaitPageLoadAndRun());
+    window.addEventListener('urlchange', (info) => {
+        isMybonusPage = isBonusParamPage()
+        if (!isIgnoredSite() && !(isSiteDisabledByInvalidBonusPage() && !isMybonusPage)) {
+            MTteamWaitPageLoadAndRun()
+        }
+    });
 }


### PR DESCRIPTION
## 变更内容

- 扩展脚本匹配范围：
  - 根据 PT 监护室健康站点列表增加更多 PT 站点匹配规则。
  - 同时覆盖主域名和子域名的 `torrents*` 页面。
  - 增加部分站点的 `mybonus*` / `bonus*` 页面匹配。

- 改进通用种子列表兼容性：
  - 增加更通用的种子表格定位逻辑。
  - 支持更多 NexusPHP 类站点的时间、体积、做种人数列识别。
  - 改进非标准 `torrents` 表格结构下的 A 值列插入。

- 改进 M-Team 适配：
  - 适配新版 M-Team 页面结构。
  - 改进 M-Team `/mybonus` 页面参数提取。
  - 支持新版文本格式中的 `T0`、`N0`、`B0`、`L` 参数解析。
  - 处理 M-Team 基本奖励中做种数奖励对 B-A 图的影响。

- 改进魔力参数解析：
  - 增加更稳健的参数提取逻辑。
  - 支持页面文本中不同格式的 `T0/N0/B0/L` 写法。
  - 参数存储支持主域名和完整 host 的兼容读取。

- 排除不兼容站点：
  - `qingwapt.com`
  - `audiences.me`
  - `hdarea.club`
  - `hhanclub.net`
  - `monikadesign.uk`

- 增加 `/mybonus.php` 解析失败后的停用机制：
  - 如果某站 `/mybonus.php` 无法解析出公式参数，会记录为不兼容站点。
  - 后续该站的非 `/mybonus.php` 页面默认不再启用脚本功能。
  - 重新打开 `/mybonus.php` 时仍允许再次解析；解析成功后会清除停用标记。

- 更新 README：
  - 补充站点匹配范围说明。
  - 补充 M-Team 适配说明。
  - 补充不兼容站点和 `/mybonus.php` 解析失败处理说明。

## 验证

- `node --check UserScript.js`
- `git diff --check`