### PR TITLE
fix: 增强魔力值参数提取的鲁棒性

### DIFF
--- a/UserScript.js
+++ b/UserScript.js
@@ -477,8 +477,23 @@ const siteInfo = [
 let site;
 
 function getParamsFromBonusPage() {
-    let argsReady = true;
     let siteName = site.name;
+
+    // 检查该站点是否已被标记为"无法自动获取参数"
+    let bonusBlocked = GM_getValue(siteName + ".bonus_blocked");
+    if (bonusBlocked) {
+        console.log('[PTMyBonusCalc] 该站点已标记为无法自动获取魔力值参数，跳过。');
+        let T0 = GM_getValue(siteName + ".T0");
+        let N0 = GM_getValue(siteName + ".N0");
+        let B0 = GM_getValue(siteName + ".B0");
+        let L = GM_getValue(siteName + ".L");
+        if (T0 && N0 && B0 && L) {
+            return {T0: T0, N0: N0, B0: B0, L: L};
+        }
+        return null;
+    }
+
+    let argsReady = true;
     let T0 = GM_getValue(siteName + ".T0");
     let N0 = GM_getValue(siteName + ".N0");
     let B0 = GM_getValue(siteName + ".B0");
@@ -495,6 +510,12 @@ function getParamsFromBonusPage() {
         console.log('数据提取成功:', newT0, newN0, newB0, newL);
     } catch (error) {
         console.error('数据提取过程中出现错误:', error);
+        GM_setValue(siteName + ".bonus_blocked", true);
+        Toastify({
+            text: "魔力值参数获取失败，该站点已记录，后续不再自动获取。请手动配置参数。",
+            duration: 5000,
+            close: true
+        }).showToast();
         return null;
     }
 
@@ -509,6 +530,8 @@ function getParamsFromBonusPage() {
         GM_setValue(siteName + ".B0", newB0);
         GM_setValue(siteName + ".L", newL);
     }
+    // 提取成功，清除可能存在的 blocked 标记
+    GM_setValue(siteName + ".bonus_blocked", false);
     return {T0: newT0, N0: newN0, B0: newB0, L: newL};
 }
 
@@ -791,7 +814,7 @@ function makeA($this, i_T, i_S, i_N) {
     }
     // 适配tjupt的发生时间
     if (time == undefined || time == "") {
-        time = $this.children('td:eq(' + i_T + ')').html().replace("<br>", " ").trim();
+        time = $this.children('td:eq(' + i_T + ')').html().replace(/<br\s*\/?>/gi, " ").trim();
     }
     var T = (new Date().getTime() - new Date(time).getTime()) / 1e3 / 86400 / 7;
     var size = $this.children('td:eq(' + i_S + ')').text().trim();


### PR DESCRIPTION
### 变更内容

1. **兼容多种 <br> 变体**
   - 将 `makeA()` 中硬编码的 `<br>` 替换替换为正则表达式 `<br\s*\/?>/gi`
   - 同时兼容 `<br>`、`<br/>`、`<br />` 等写法

2. **新增 bonus_blocked 防重复报错机制**
   - 当站点魔力值参数提取失败时，自动标记该站点为 `bonus_blocked`
   - 后续访问该站点的 `/mybonus` 页面时，跳过自动提取，避免重复报错
   - 若之前已成功缓存参数，则直接返回缓存值
   - 提取成功时自动清除 blocked 标记