### PR TITLE
修复图表选择器兼容性问题 (#34)

### DIFF
--- a/UserScript.js
+++ b/UserScript.js
@@ -563,7 +563,7 @@ function drawChart(bonusParams) {
         return Math.tan(B / B0 / (2 / Math.PI)) * L
     }
 
-    let A = isMTeam ? 0 : parseFloat($("div:contains(' (A = ')")[0].innerText.split(" = ")[1]);
+    let A = isMTeam ? 0 : parseFloat($("div:contains('A = ')")[0].innerText.split(" = ")[1]);
     let B = isMTeam ? parseFloat($("td:contains('基本獎勵')+td+td")[0].innerText) : calcB(A);
     // 剔除M-Team的基本奖励中做种数奖励
     if (isMTeam) {
@@ -594,7 +594,7 @@ function drawChart(bonusParams) {
         data.push([i, calcB(i)])
     }
 
-    let insertPos = isMTeam ? $("ul+table") : $("table+h1")
+    let insertPos = isMTeam ? $("ul+table") : $("table~h1")
     insertPos.before('<div id="main" style="width: 600px;height:400px; margin:auto;"></div>')
 
     var myChart = echarts.init(document.getElementById('main'));
@@ -754,7 +754,7 @@ function getParamsFromFetch() {
             newN0 = parseFloat($html.find("li:has(b:contains('N0'))")[1].innerText.split(" = ")[1]);
             newB0 = parseFloat($html.find("li:has(b:contains('B0'))")[1].innerText.split(" = ")[1]);
             newL = parseFloat($html.find("li:has(b:contains('L'))")[1].innerText.split(" = ")[1]);
-            a = parseFloat($html.find("div:contains(' (A = ')")[0].innerText.split(" = ")[1]);
+            a = parseFloat($html.find("div:contains('A = ')")[0].innerText.split(" = ")[1]);
             storageData();
         });
     }


### PR DESCRIPTION
来源：#34

改动内容：
- 放宽 A 参数文本匹配：div:contains(' (A = ') → div:contains('A = ')
- 插入点选择器从相邻兄弟改为通用兄弟：table+h1 → table~h1
- 同样放宽 fetch 获取 A 参数时的选择器

这些调整让脚本在页面文本/结构发生小幅变化时仍能正确定位参数并插入图表。